### PR TITLE
Tighten CI checks and add CLAUDE.md

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -20,15 +20,25 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@61e01a43a562a89bfc54c7f9a378ff67b03e4a21 # v1.16.0
       with:
-        elixir-version: '1.15.2'
-        otp-version: '26.0'
+        elixir-version: '1.19.5'
+        otp-version: '28'
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:
         path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
+        key: ${{ runner.os }}-otp28-elixir1.19-mix-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-otp28-elixir1.19-mix-
     - name: Install dependencies
       run: mix deps.get
+    - name: Check unused dependencies
+      run: mix deps.unlock --check-unused
+    - name: Check formatting
+      run: mix format --check-formatted
+    - name: Audit Hex dependencies
+      run: mix hex.audit
+    - name: Compile (warnings as errors)
+      run: mix compile --warnings-as-errors
+    - name: Build docs (warnings as errors)
+      run: mix docs --warnings-as-errors
     - name: Run tests
       run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Elixir
       uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
       with:
         elixir-version: '1.19.5'
         otp-version: '28'
     - name: Restore dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-otp28-elixir1.19-mix-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir
-      uses: erlef/setup-beam@61e01a43a562a89bfc54c7f9a378ff67b03e4a21 # v1.16.0
+      uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
       with:
         elixir-version: '1.19.5'
         otp-version: '28'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,7 @@ Bier is an early-stage (alpha) Elixir library that aims to serve a RESTful API g
 
 ## Toolchain
 
-- Elixir/OTP versions are pinned in `mise.toml` (Elixir 1.19.5 / OTP 28). `mix.exs` declares `elixir: "~> 1.18"`.
-- Note: `.github/workflows/elixir.yml` still pins Elixir 1.15.2 / OTP 26.0 — the CI matrix is older than the local toolchain.
+Elixir/OTP versions are pinned in `mise.toml` (Elixir 1.19.5 / OTP 28) and matched in `.github/workflows/elixir.yml`. `mix.exs` declares the lower bound at `elixir: "~> 1.18"`.
 
 ## Common commands
 
@@ -21,7 +20,17 @@ mix test test/path/to/file_test.exs:LINE   # single test by file:line
 mix format            # uses .formatter.exs
 ```
 
-There is no lint/dialyzer/credo step configured.
+CI runs these gates before `mix test`, so run them locally before pushing to avoid red builds:
+
+```sh
+mix deps.unlock --check-unused
+mix format --check-formatted
+mix hex.audit
+mix compile --warnings-as-errors
+mix docs --warnings-as-errors
+```
+
+No credo or dialyzer step is configured.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project status
+
+Bier is an early-stage (alpha) Elixir library that aims to serve a RESTful API generated on-the-fly from PostgreSQL DB introspection — heavily inspired by PostgREST. The README is the source of truth for the design intent and includes the two key sequence diagrams (boot flow and request flow). Several pieces called out in the README are intentional placeholders today: DB introspection is stubbed, `Bier.Plugs.ActionController` returns canned responses, and `QueryParser` / `QueryExecutor` (and authentication) do not yet exist.
+
+## Toolchain
+
+- Elixir/OTP versions are pinned in `mise.toml` (Elixir 1.19.5 / OTP 28). `mix.exs` declares `elixir: "~> 1.18"`.
+- Note: `.github/workflows/elixir.yml` still pins Elixir 1.15.2 / OTP 26.0 — the CI matrix is older than the local toolchain.
+
+## Common commands
+
+```sh
+mix deps.get          # fetch dependencies
+mix compile
+mix test              # run the full suite
+mix test test/path/to/file_test.exs:LINE   # single test by file:line
+mix format            # uses .formatter.exs
+```
+
+There is no lint/dialyzer/credo step configured.
+
+## Architecture
+
+### Two-layer supervision (intentional)
+
+There are two distinct supervisors and they do different things:
+
+1. **`Bier.Application`** (`mix.exs` `mod:`) starts only **`Bier.Registry`** — a process registry shared across all Bier instances in the BEAM node. It does NOT start an HTTP server.
+2. **`Bier`** is itself a `Supervisor` that the host application starts via `Bier.start_link/1` (or as a child spec). Each call creates one *named instance* with its own config, its own Bandit server, and its own dynamically-generated Router module. Multiple instances coexist by passing distinct `:name` options.
+
+Implication: do not put per-instance state in `Bier.Application`. Anything tied to a configured instance belongs under the `Bier` supervisor and should be registered through `Bier.Registry.via/3`.
+
+### Per-instance process naming
+
+`Bier.Registry` is a standard Elixir `Registry` (`keys: :unique`). All instance-scoped processes are registered with `{:via, Registry, {Bier.Registry, key}}` tuples produced by `Bier.Registry.via/3`. The key is either the instance name, or `{name, role}` where role disambiguates (e.g. `DynamicSupervisor`, `Bier.HttpServerStarter`). The supervisor's via-tuple also stashes the validated `Bier.Config` as the registry value, which is how `Bier.Registry.config/1` retrieves it without a GenServer call.
+
+### Boot sequence (current state)
+
+`Bier.start_link/1` → validates opts via `Bier.Config.new!/2` (NimbleOptions schema in `lib/bier.ex`) → starts `Bier.HttpServerStarter` and a per-instance `DynamicSupervisor`. `HttpServerStarter.init/1` runs (today: fakes) DB introspection, then calls `Bier.RouterBuilder.build/2`, then `handle_continue(:start_webserver, …)` starts Bandit as a child of that DynamicSupervisor with the freshly built plug.
+
+### Dynamic router generation
+
+`Bier.RouterBuilder.build/2` creates a brand-new module at runtime using `Module.create/3` with quoted `Plug.Router` content. The module is named `<instance_name>.Router` (e.g. `Bier.Router` for the default instance — so two instances must have different `:name` values to avoid module redefinition). For each entry in `db_structure` it emits `get/post/delete` routes pointing to `Bier.Plugs.ActionController` with `init_opts` set to the action atom (`:index | :post | :delete`) and `assigns` carrying `supervisor_name`, `schema`, and `table_name`. Anything that doesn't match falls through to `Bier.Plugs.FallbackController` with `:not_found`.
+
+When changing routing/dispatch semantics, edit the quoted block inside `RouterBuilder` — the generated module is rebuilt every boot, so it is not checked in and grepping for routes won't find them.
+
+### Controllers
+
+`Bier.Plugs.ActionController.call/2` dispatches by the `init_opts` action atom and lets a non-`Plug.Conn` return value fall through to `FallbackController.call/2`, which pattern-matches on shapes like `{:error, :bad_request}`, `{:error, :mismatch}`, `%{code: :insufficient_privilege}`, and `%{code: :foreign_key_violation}`. New error shapes should be added as additional `FallbackController.call/2` clauses rather than handled inline in the action.
+
+### Pluggable JSON
+
+`Bier.json_library/0` returns the configured encoder (defaults to the stdlib `JSON` module, requires Elixir 1.18+). Any new code that serializes responses should go through it rather than calling `Jason`/`JSON` directly, so host apps can override via `config :bier, :json_library, …`.
+
+## Test layout
+
+`test/support/` is added to `elixirc_paths` only in `:test` (see `mix.exs`). Put shared fixtures/helpers there. The current suite is essentially empty (`test/bier_test.exs`).

--- a/lib/bier.ex
+++ b/lib/bier.ex
@@ -1,7 +1,24 @@
 defmodule Bier do
-  # TODO: Put something more here, maybe reading the README docs? once you have
-  # something there of course
-  @moduledoc false
+  @moduledoc """
+  Public entry point for a Bier instance.
+
+  `Bier` is a `Supervisor` that the host application starts to spin up one
+  named instance — its own validated configuration, its own Bandit web server,
+  and its own router built on the fly from database introspection. Multiple
+  instances can coexist in the same node by passing distinct `:name` values.
+
+  ## Usage
+
+  Add a `Bier` child to your application's supervision tree:
+
+      children = [
+        {Bier, name: MyApp.Bier, router: [port: 4040, scheme: :http]}
+      ]
+
+  See `start_link/1` for the full list of options.
+
+  Per-instance processes are registered through `Bier.Registry`.
+  """
 
   @schema [
     name: [


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` to brief future Claude Code sessions on the project's two-layer supervision, per-instance via-tuple naming, and runtime router generation.
- Bump `.github/workflows/elixir.yml` to Elixir 1.19.5 / OTP 28 (matches `mise.toml`) and add `mix deps.unlock --check-unused`, `mix format --check-formatted`, `mix hex.audit`, `mix compile --warnings-as-errors`, and `mix docs --warnings-as-errors` before `mix test`. Cache key now includes the toolchain version.
- Replace `Bier`'s `@moduledoc false` with a real moduledoc so the new docs check passes (`Bier.Registry`'s specs reference `Bier.name()`, which can't be linked from a hidden module).

## Test plan
- [ ] CI runs the new steps and they pass on this branch
- [ ] `mix docs` renders the `Bier` module page without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)