### PR TITLE
test(harness): send body_json/body_raw request bodies (closes #12)

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -84,7 +84,7 @@ jobs:
       # failures INCREASE (a real regression). Lower BASELINE_FAILURES as the
       # harness/env issues are fixed.
       env:
-        BASELINE_FAILURES: '32'
+        BASELINE_FAILURES: '24'
       run: |
         set -o pipefail
         mix test 2>&1 | tee test_output.txt || true

--- a/test/support/http_case.ex
+++ b/test/support/http_case.ex
@@ -34,7 +34,7 @@ defmodule Bier.HttpCase do
         method: method,
         url: url,
         headers: build_headers(req, schema),
-        body: encode_body(Map.get(req, "body")),
+        body: request_body(req),
         decode_body: false,
         retry: false
       )
@@ -84,6 +84,15 @@ defmodule Bier.HttpCase do
        do: "%" <> (byte |> Integer.to_string(16) |> String.upcase() |> String.pad_leading(2, "0"))
 
   defp encode_byte(byte), do: <<byte>>
+
+  # A case carries at most one request-body form:
+  #   * `body_raw`  — sent verbatim (CSV, deliberately-invalid JSON, octet bytes)
+  #   * `body_json` — the value is always JSON-encoded
+  #   * `body`      — JSON-encoded unless already a string
+  defp request_body(%{"body_raw" => raw}), do: raw
+  defp request_body(%{"body_json" => json}), do: Bier.json_library().encode!(json)
+  defp request_body(%{"body" => body}), do: encode_body(body)
+  defp request_body(_), do: nil
 
   defp encode_body(nil), do: nil
   defp encode_body(body) when is_binary(body), do: body


### PR DESCRIPTION
Closes #12.

## Problem
`Bier.HttpCase.perform/1` only read `request["body"]`. Cases that specify their body as **`body_json`** (a value to JSON-encode) or **`body_raw`** (verbatim bytes — CSV, deliberately-invalid JSON, octet-stream) reached the server **bodyless** and failed (`23502 not-null`, "Empty or invalid json", etc.).

## Fix
A small `request_body/1` picks the single body form a case carries:
- `body_raw` → sent verbatim
- `body_json` → always JSON-encoded
- `body` → JSON-encoded unless already a string (unchanged)

## Result
**32 → 24 failures (+8)**, deterministic, a **strict subset** of the prior failures (no regressions). Newly passing:
- content_negotiation: `1609` (csv ragged-rows error), `1613` (singular multiple-rows error), `1614` (singular post-insert), `1615` (singular rpc json)
- domain_representations writes: `1811`, `1812`, `1813`, `1814`

Verified the previously-passing `body_raw`/`body_json` cases (`1420`, `1426`, `1608`) still pass. CI ratchet baseline lowered **32 → 24**.

## Remaining 24
#11 Content-Length (now diagnosed as a Mint limitation — needs an HTTP-client swap, see the issue comment) · #13 Set-Cookie · #14 per-case `config:` · #15 PostGIS · #16 cs/cd fixture seed · #17 compact JSON (`1320`/`1323`) · plus auth-structural `1467`/`1491`/`1493`.
