### PR TITLE
Fix cs/cd arr_data seed (#16) + Set-Cookie folding (#13)

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -84,7 +84,7 @@ jobs:
       # failures INCREASE (a real regression). Lower BASELINE_FAILURES as the
       # harness/env issues are fixed.
       env:
-        BASELINE_FAILURES: '24'
+        BASELINE_FAILURES: '21'
       run: |
         set -o pipefail
         mix test 2>&1 | tee test_output.txt || true

--- a/lib/mix/tasks/bier.fixtures.load.ex
+++ b/lib/mix/tasks/bier.fixtures.load.ex
@@ -102,8 +102,18 @@ defmodule Mix.Tasks.Bier.Fixtures.Load do
   #   * `test.complex_items."field-with_sep"` is asserted to equal the row id by
   #     the select cases (QuerySpec column-projection examples), but the merged
   #     INSERT omits the column so it defaults to 1. Set it to match the id.
+  #   * `test.complex_items.arr_data`: the consolidator took mutations' seed
+  #     ({1,2,3} for every row), but operators' cs/cd cases (1072/1073) need
+  #     PostgREST's per-row {1}, {1,2}, {1,2,3} (row N -> {1..N}). Row 3 stays
+  #     {1,2,3}, so the select case (1100) that reads it is unaffected.
   defp seed_corrections(psql, cfg) do
-    sql = ~s(UPDATE test.complex_items SET "field-with_sep" = id;)
+    sql = """
+    UPDATE test.complex_items SET "field-with_sep" = id;
+    UPDATE test.complex_items
+       SET arr_data = ARRAY(SELECT generate_series(1, id))
+     WHERE id IN (1, 2, 3);
+    """
+
     run_psql!(psql, cfg, cfg[:database], sql)
   end
 

--- a/test/support/http_case.ex
+++ b/test/support/http_case.ex
@@ -98,9 +98,16 @@ defmodule Bier.HttpCase do
   defp encode_body(body) when is_binary(body), do: body
   defp encode_body(body), do: Bier.json_library().encode!(body)
 
-  # Req returns headers as %{"name" => [values]} with downcased names.
+  # Req returns headers as %{"name" => [values]} with downcased names. Repeated
+  # headers are folded with ", " — except `Set-Cookie`, whose values legitimately
+  # contain commas (e.g. the `Expires` date), so it must never be comma-folded;
+  # repeated cookies are joined with "\n", the encoding the cases use (case 1568).
   defp normalize_headers(headers) do
-    Map.new(headers, fn {k, v} -> {String.downcase(k), v |> List.wrap() |> Enum.join(", ")} end)
+    Map.new(headers, fn {k, v} ->
+      key = String.downcase(k)
+      sep = if key == "set-cookie", do: "\n", else: ", "
+      {key, v |> List.wrap() |> Enum.join(sep)}
+    end)
   end
 
   defp to_method(str), do: Map.fetch!(@http_methods, String.upcase(str))


### PR DESCRIPTION
Two small fixes; **24 → 21 failures**, deterministic, strict subset (no regressions).

## #16 — `complex_items.arr_data` seed (closes #16)
The consolidated fixture seeded `arr_data = {1,2,3}` for **every** row (it took the mutations fragment's seed), but operators' cs/cd cases need PostgREST's per-row values:
- `1072` `arr_data=cs.{2}` → `[2,3]`
- `1073` `arr_data=cd.{1,2,4}` → `[1,2]`

Fixed in the loader's `seed_corrections` (alongside the sibling `field-with_sep` correction) — set `arr_data = {1..N}` for row N. The generated `fixtures.sql` is "do not edit", and the `select.sql` fragment already had the right values; the consolidation chose the wrong one. Row 3 stays `{1,2,3}`, so the select case `1100` that reads it is unaffected (verified, along with `1361`/`1371`).

## #13 — don't comma-fold Set-Cookie (closes #13)
`normalize_headers/1` joined repeated headers with `", "`, which corrupts `Set-Cookie` — its values legitimately contain commas (`Expires=Wed, 21 Oct 2015 …`), so they can't be recovered. Join `Set-Cookie` with `"\n"` instead (the cases' encoding; PostgREST emits two distinct `Set-Cookie` headers). Case `1568` passes. Single-cookie responses are unaffected (a 1-element join applies no separator).

CI ratchet baseline lowered **24 → 21**.

## Remaining 21
All in the larger buckets: #11 Content-Length (now diagnosed as a Mint limitation — needs an HTTP-client swap), #14 per-case `config:` (incl. auth-structural 1467/1491/1493), #15 PostGIS, #17 compact JSON (1320/1323).
