### PR TITLE
docs: refresh README + CLAUDE.md to match current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project status
 
-Bier is an early-stage (alpha) Elixir library that aims to serve a RESTful API generated on-the-fly from PostgreSQL DB introspection — heavily inspired by PostgREST. The README is the source of truth for the design intent and includes the two key sequence diagrams (boot flow and request flow). Several pieces called out in the README are intentional placeholders today: DB introspection is stubbed, `Bier.Plugs.ActionController` returns canned responses, and `QueryParser` / `QueryExecutor` (and authentication) do not yet exist.
+Bier is an alpha Elixir library that serves a RESTful API generated on-the-fly from PostgreSQL DB introspection — heavily inspired by PostgREST. The README is the source of truth for the design intent and includes the two key sequence diagrams (boot flow and request flow).
+
+The pipeline is real, not stubbed: `Bier.Introspection` queries `pg_catalog`; `Bier.Plugs.ActionController` resolves the target and runs the read/mutation/RPC path; `Bier.QueryParser` (a generated, dependency-free parser) and `Bier.QueryExecutor` build and run one parameterized JSON query; `Bier.Auth` does HS256 JWT verification + role/GUC setup. Development is driven by a frozen conformance suite derived from PostgREST v14.12 (see `docs/CONFORMANCE_IMPL.md` and `spec/`). Known feature gaps (observability/telemetry, schema-cache reload, admin/health endpoints, asymmetric JWT) are tracked as GitHub issues.
 
 ## Toolchain
 
@@ -15,10 +17,17 @@ Elixir/OTP versions are pinned in `mise.toml` (Elixir 1.19.5 / OTP 28) and match
 ```sh
 mix deps.get          # fetch dependencies
 mix compile
-mix test              # run the full suite
+mix test              # loads the fixture DB, then runs the full suite
 mix test test/path/to/file_test.exs:LINE   # single test by file:line
+mix test --only area:<area>                # one conformance area (e.g. area:operators)
 mix format            # uses .formatter.exs
+mix gen.parsers       # regenerate the parser modules from their *.ex.exs templates
 ```
+
+`mix test` is aliased to `["bier.fixtures.load", "test"]` (`mix.exs`), so it
+drops+recreates a local `bier_test` PostgreSQL database and loads
+`spec/conformance/fixtures.sql` before running. A reachable local Postgres is
+required; see `docs/CONFORMANCE_IMPL.md` for the wiring.
 
 CI runs these gates before `mix test`, so run them locally before pushing to avoid red builds:
 
@@ -49,17 +58,31 @@ Implication: do not put per-instance state in `Bier.Application`. Anything tied 
 
 ### Boot sequence (current state)
 
-`Bier.start_link/1` → validates opts via `Bier.Config.new!/2` (NimbleOptions schema in `lib/bier.ex`) → starts `Bier.HttpServerStarter` and a per-instance `DynamicSupervisor`. `HttpServerStarter.init/1` runs (today: fakes) DB introspection, then calls `Bier.RouterBuilder.build/2`, then `handle_continue(:start_webserver, …)` starts Bandit as a child of that DynamicSupervisor with the freshly built plug.
+`Bier.start_link/1` → validates opts via `Bier.Config.new!/2` (NimbleOptions schema in `Bier.schema/0`, `lib/bier.ex`; defaults sourced from application env) → the `Bier` supervisor starts three children in order: a per-instance **`Postgrex` pool** (registered via `Bier.Registry.via(name, Postgrex)`), a per-instance **`DynamicSupervisor`**, then **`Bier.HttpServerStarter`**. The pool and DynamicSupervisor must come first: `HttpServerStarter.init/1` uses the pool for introspection, and its `handle_continue(:start_webserver, …)` starts Bandit *as a child of the DynamicSupervisor*.
+
+`HttpServerStarter.init/1` runs real introspection — `Bier.Introspection.run/functions/media_handlers(pool, db_schemas)` — and stashes the results in **`:persistent_term`** keyed by `{Bier, :relations | :functions | :media_handlers, name}` (read on every request). It then calls `Bier.RouterBuilder.build/2` and starts Bandit with `http_options: [compress: false]` (PostgREST never compresses and always emits `Content-Length`; Bandit otherwise strips it).
 
 ### Dynamic router generation
 
-`Bier.RouterBuilder.build/2` creates a brand-new module at runtime using `Module.create/3` with quoted `Plug.Router` content. The module is named `<instance_name>.Router` (e.g. `Bier.Router` for the default instance — so two instances must have different `:name` values to avoid module redefinition). For each entry in `db_structure` it emits `get/post/delete` routes pointing to `Bier.Plugs.ActionController` with `init_opts` set to the action atom (`:index | :post | :delete`) and `assigns` carrying `supervisor_name`, `schema`, and `table_name`. Anything that doesn't match falls through to `Bier.Plugs.FallbackController` with `:not_found`.
+`Bier.RouterBuilder.build/2` creates a brand-new module at runtime using `Module.create/3` with quoted `Plug.Router` content, named `<instance_name>.Router` (so two instances must have different `:name` values to avoid module redefinition). It is a thin **catch-all**: a fixed plug pipeline (`:match` → `assign_instance` → `Bier.Plugs.Cors` → `Bier.Plugs.Observability` → `Bier.Plugs.ReadBody` → `:dispatch`) and a single `match _` that forwards every request to `Bier.Plugs.ActionController`. The per-table `get/post/delete` generation is gone — Accept-Profile schema resolution and `/rpc/*` can't be expressed as static routes, so the target `{schema, relation}` is resolved at request time instead.
 
 When changing routing/dispatch semantics, edit the quoted block inside `RouterBuilder` — the generated module is rebuilt every boot, so it is not checked in and grepping for routes won't find them.
 
-### Controllers
+### Controllers and the request pipeline
 
-`Bier.Plugs.ActionController.call/2` dispatches by the `init_opts` action atom and lets a non-`Plug.Conn` return value fall through to `FallbackController.call/2`, which pattern-matches on shapes like `{:error, :bad_request}`, `{:error, :mismatch}`, `%{code: :insufficient_privilege}`, and `%{code: :foreign_key_violation}`. New error shapes should be added as additional `FallbackController.call/2` clauses rather than handled inline in the action.
+`Bier.Plugs.ActionController.call/2` resolves the target `{schema, relation}` from the path + `Accept-Profile`/`Content-Profile` (default schema = first of `db_schemas`), runs `Bier.Auth.resolve` for schemas that require it (auth is inline here, not a separate plug), then dispatches by path/method:
+
+- root `/` → OpenAPI document (or `db_root_spec`);
+- `OPTIONS` → `Allow` header;
+- `/rpc/<fn>` → `Bier.Rpc.dispatch`;
+- relation `GET`/`HEAD` → `Bier.Negotiation` → `Bier.QueryParser.parse_request` → `Bier.QueryExecutor.run` (one parameterized SQL → JSON) → `Bier.Response`/`Bier.Render`;
+- relation `POST`/`PATCH`/`PUT`/`DELETE` → `Bier.Mutation.handle`.
+
+Any non-`Plug.Conn` return value falls through to `Bier.Plugs.FallbackController.call/2`, which maps internal reasons and Postgres `SQLSTATE`s to HTTP statuses and PostgREST's `{code, message, details, hint}` envelope (`PGRST*` codes). New error shapes should be added as additional `FallbackController.call/2` clauses rather than handled inline in `ActionController`.
+
+### The query parser (generated)
+
+`lib/bier/query_parser.ex` and `lib/bier/query_parser/nimble.ex` are **generated**, dependency-free modules built from `*.ex.exs` templates via `mix gen.parsers` (which runs `mix nimble_parsec.compile`). `nimble_parsec` is a `:dev`-only dep (`runtime: false`); the shipped code does not depend on it. Edit the `.ex.exs` template, run `mix gen.parsers`, and commit both the template and the regenerated `.ex` (the `.ex` is what `mix compile` reads — never edit it directly).
 
 ### Pluggable JSON
 
@@ -67,4 +90,6 @@ When changing routing/dispatch semantics, edit the quoted block inside `RouterBu
 
 ## Test layout
 
-`test/support/` is added to `elixirc_paths` only in `:test` (see `mix.exs`). Put shared fixtures/helpers there. The current suite is essentially empty (`test/bier_test.exs`).
+`test/support/` is added to `elixirc_paths` only in `:test` (see `mix.exs`). Put shared fixtures/helpers there.
+
+The suite is driven by the **conformance cases** in `test/conformance/conformance_test.exs`, which generates one ExUnit test per case in `spec/` (532 cases, ~475 active; `:pending` cases for jwt/jsonpath/status_text/cli are excluded). Each case is tagged `@tag area: :<area>`. The harness under `test/support/` — `Bier.ConformanceServer` (boots one shared instance), `Bier.HttpCase.perform/1` (issues the request via `Req`), and `Bier.ConformanceAssertions` — plus everything under `spec/` is **frozen ground truth**: it encodes real PostgREST v14.12 behavior. Fix `lib/` to match the cases, never edit `test/**` or `spec/**`. See `docs/CONFORMANCE_IMPL.md` for the full contract.

--- a/README.md
+++ b/README.md
@@ -1,106 +1,268 @@
 # Bier
 
-**WARNING:** This project is in its first stage. Be aware this project may contain bugs or possibly security flaws. This implementation is **not** ready for production use.
+> **Alpha.** Bier is in its first stage. Expect bugs and possibly security
+> flaws — it is **not** ready for production use.
 
-## What is Bier?
+Bier is an Elixir library that serves a RESTful API generated **on the fly** from
+PostgreSQL introspection: point it at a database and it inspects the tables,
+views, functions, and foreign keys and exposes them over HTTP — no controllers,
+no route files, no schema definitions to write. It is heavily inspired by
+[PostgREST][], and tracks PostgREST's request/response behavior closely (see
+[Conformance](#conformance)).
 
-A friend reached out today via Slack and caught me off base; our conversation went something like this:
+## How it works, in one paragraph
 
-> Him: what is bier <br />
-> Me: hahaha <br />
-> Him: you have to tell me <br />
-> Me: it's like an urn :funeral_urn: <br />
-> Him: hahahaha you butt <br />
-> Him: WHAT IS THE ELIXIR LIBRARY YOU ARE PLAYING WITH IN YOUR OFFTIME THAT YOU NAMED BIER MILTON
+Each Bier instance is a supervision tree the host application starts. On boot it
+opens a [Postgrex][] connection pool, introspects the configured schemas, builds
+a [Plug.Router][] module at runtime, and starts a [Bandit][] web server with it.
+Every incoming request is resolved to a `{schema, relation}` at request time and
+compiled into **one** parameterized SQL statement that returns its result set as
+JSON, which is then rendered in the negotiated media type.
 
-So, I explained the basic idea to him, but now I wonder if he or other people want to know more details, so here I will offer a detailed explanation.
+## Installation
 
-While Elixir is still my favorite programming language and primary interest. Since some time ago, I've been getting deeper into [PostgreSQL][]. It's a nice piece of software that constantly surprises you in good ways. Anyway, an exciting project would be to serve a RESTful API based on DB introspection, meaning that this library on the fly will introspect your DB and, based on the structure, constraints, and permissions, will build a RESTful API for you. This idea is not original; you probably already know about [PostgREST][], so this project is heavily inspired by that idea and my desire to explore more about [PostgreSQL][].
+Not yet published to Hex. Add it as a git dependency:
 
-On the Elixir side, this project will allow me to explore some cool things; as I envision this project so far, those things are:
+```elixir
+def deps do
+  [
+    {:bier, github: "milmazz/bier"}
+  ]
+end
+```
 
-* Explore [Bandit][], as an HTTP server.
-* Provide `Bier` as a supervisor so the library users can create as many instances as they need. It would be weird, but that's already implemented, and all the generated processes are registered via `Bier.Registry`.
-* Before building the Router with `Bier.RouterBuilder`, we must call the DB and run queries to introspect the DB structure. Based on that structure, we will proceed to the next step.
-* Build the Router directly with [Plug.Router](https://hexdocs.pm/plug/Plug.Router.html) and start [Bandit] programmatically in `Bier.HttpServerStarter`
-* It's not clear to me at this point if we should create a migration to subscribe to possible changes in the DB (e.g., new tables) with something like `Postgrex.Notifications`, and once we catch those changes in `Bier.HttpServerStarter` rebuild the Router and inject that back to [Bandit][]
-* Once we have the HTTP Server running, the incoming requests should end on what I call `Bier.Plugs.ActionController`; here, we should parse the queries into an internal AST using [NimbleParsec][], at this point, is not clear to me if that after the parsing phase, the execution should transform that AST into [Ecto][] Queries or just go straight with something like `Postgrex`. Based on the query's result, we should return the response to the client if it was successful. Otherwise, the flow will end with the `Bier.Plugs.FallbackController`.
+Requires Elixir `~> 1.18` (developed against Elixir 1.19 / OTP 28) and a
+reachable PostgreSQL instance. Bier pulls in [Bandit][], [Plug][], [Postgrex][],
+and [NimbleOptions][] as runtime dependencies.
 
-To summarize, at this _alpha_ stage, I still have too many things to figure out, but I think that the following sequence diagram should wrap up the whole idea:
+## Usage
+
+Add a `Bier` child to your application's supervision tree. Each child is one
+**named instance** with its own config, connection pool, and web server;
+multiple instances coexist by passing distinct `:name` values.
+
+```elixir
+children = [
+  {Bier,
+   name: MyApp.Bier,
+   router: [port: 4040, scheme: :http],
+   database: "my_app_dev",
+   username: "postgres",
+   password: "postgres",
+   db_schemas: ["api"]}
+]
+
+Supervisor.start_link(children, strategy: :one_for_one)
+```
+
+Once it is up, the database is reachable over HTTP, e.g.:
+
+```sh
+# read rows, filter, select columns, order, paginate
+curl "http://localhost:4040/items?select=id,name&age=gte.18&order=name.asc&limit=10"
+
+# insert and get the row back
+curl -X POST "http://localhost:4040/items" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{"name": "Ada"}'
+
+# call a database function
+curl "http://localhost:4040/rpc/add?a=1&b=2"
+```
+
+## Configuration
+
+Options are validated by a [NimbleOptions][] schema (`Bier.schema/0`). Their
+defaults are sourced from application env, so you can also set them under
+`config :bier, …` instead of passing them to `start_link/1`. The main keys
+(named after their PostgREST equivalents):
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `name` | `Bier` | Instance name; also the registry key and `<name>.Router` module. |
+| `router` | `[port: 4040, scheme: :http]` | Bandit web-endpoint options. |
+| `hostname` / `port` / `database` / `username` / `password` | `localhost` / `5432` / `bier` / — / — | Postgres connection. |
+| `pool_size` | `10` | Per-instance Postgrex pool size. |
+| `db_schemas` | `["public"]` | Ordered list of exposed schemas; the first is the default. |
+| `db_anon_role` | `nil` | Role assumed for unauthenticated requests. |
+| `db_extra_search_path` | `["public"]` | Extra schemas appended to the search path. |
+| `db_max_rows` | `nil` | Cap on rows returned per request. |
+| `db_tx_end` | `:commit` | End each request's transaction with `:commit` or `:rollback`. |
+| `db_pre_request` | `nil` | Function run inside every request transaction before the main query. |
+| `jwt_secret` / `jwt_aud` | `nil` | JWT verification secret and expected audience (HS256). |
+| `server_cors_allowed_origins` | `nil` | Comma-separated CORS allow-list. |
+| `server_timing_enabled` | `false` | Emit a `Server-Timing` header. |
+| `server_trace_header` | `nil` | Request header (e.g. `X-Request-Id`) echoed on the response. |
+| `log_level` | `:error` | Access-log verbosity. |
+| `openapi_mode` | `"follow-privileges"` | How the root OpenAPI document is served. |
+
+See `Bier.schema/0` for the complete, documented list.
+
+### Pluggable JSON
+
+`Bier.json_library/0` returns the configured encoder (the stdlib `JSON` module by
+default, which requires Elixir 1.18+). Override it with:
+
+```elixir
+config :bier, :json_library, Jason
+```
+
+## Architecture
+
+There are two supervisors with different jobs. `Bier.Application` (the OTP `mod:`)
+starts only `Bier.Registry`, a process registry shared by every Bier instance in
+the node — it does **not** start a web server. `Bier` itself is the per-instance
+`Supervisor` the host application starts; each instance owns its config, its
+Postgrex pool, a `DynamicSupervisor`, and a dynamically generated router module.
+
+### Boot flow
 
 ```mermaid
 sequenceDiagram
     participant A as MyApp.Application
-    participant B as Bier
+    participant B as Bier (Supervisor)
     participant C as Bier.Config
-    participant D as Bier.Repo
+    participant P as Postgrex pool
     participant E as Bier.HttpServerStarter
+    participant I as Bier.Introspection
     participant F as Bier.RouterBuilder
     participant G as Bandit
-    A->>+B: start_link
-    B->>+C: validate config
-    C->>-B: config validated
-    B->>+D: start Repo
-    D->>-B: started
-    B->>+E: start_link
-    E->>+D: Introspect DB
-    D->>-E: db_structure
-    E->>+F: build router
-    F->>-E: plug
-    E->>+G: start HTTP server
-    G->>-E: HTTP server started
-    E->>-B: HTTP server started
+    A->>+B: start_link(name:, router:, …)
+    B->>+C: new!/2 (validate opts, defaults from app env)
+    C->>-B: %Bier.Config{}
+    B->>P: start per-instance pool (via Bier.Registry)
+    B->>+E: start_link(config)
+    E->>+I: run / functions / media_handlers(pool, db_schemas)
+    I->>P: query pg_catalog
+    I->>-E: relations, functions, media handlers
+    E->>E: stash introspection in :persistent_term
+    E->>+F: build(config, relations)
+    F->>-E: <name>.Router module
+    E->>+G: start Bandit (plug: Router) under the DynamicSupervisor
+    G->>-E: listening
+    E->>-B: {:ok, state}
     B->>-A: ready
 ```
 
-Then, once the HTTP server is ready, the incoming requests should follow this pattern:
+`Bier.RouterBuilder.build/2` creates the router with `Module.create/3` at runtime,
+named `<name>.Router`. It is a thin **catch-all**: every request flows through a
+fixed plug pipeline (`:match` → `assign_instance` → `Bier.Plugs.Cors` →
+`Bier.Plugs.Observability` → `Bier.Plugs.ReadBody` → `:dispatch`) and is then
+forwarded to `Bier.Plugs.ActionController`. Because the router is regenerated on
+every boot it is not checked in, and grepping for routes will not find them — edit
+the quoted block in `RouterBuilder` instead.
+
+### Request flow
 
 ```mermaid
 sequenceDiagram
     participant C as Client
-    participant B as Bandit
-    participant R as Router
-    participant P as Plug.Parsers
-    participant A as Bier.Plugs.AuthenticateUser
+    participant G as Bandit
+    participant R as <name>.Router
     participant AC as Bier.Plugs.ActionController
-    participant QP as QueryParser
-    participant QE as QueryExecutor
+    participant AU as Bier.Auth
+    participant QP as Bier.QueryParser
+    participant QE as Bier.QueryExecutor
+    participant RN as Bier.Response / Render
     participant FC as Bier.Plugs.FallbackController
-    C->>+B: request
-    B->>+R: route
-    R->>+P: parse
-    P->>-R: conn
-    R->>+A: authenticate
-    A->>-R: conn
-    R->>+AC: resolve action
-    AC->>+QP: parse
-    QP->>-AC: AST
-    AC->>+QE: execute
-    QE->>-AC: result
-    alt is ok
-    AC->>AC: transform result
-    AC->>-B: conn
-    else not ok
-    AC->>FC: handle error
-    FC->>FC: transform
-    FC->>B: conn
+    C->>+G: HTTP request
+    G->>+R: catch-all match
+    R->>R: :match → assign_instance → Cors → Observability → ReadBody → :dispatch
+    R->>+AC: call/2
+    AC->>AC: resolve {schema, relation} from path + Accept/Content-Profile
+    opt schema requires auth
+        AC->>+AU: resolve (JWT verify, SET LOCAL ROLE, request.* GUCs)
+        AU->>-AC: auth context
     end
-    B->>-C: response
+    alt GET / HEAD
+        AC->>+QP: parse_request(query_string)
+        QP->>-AC: plan (select / filter / order / limit / embed)
+        AC->>+QE: run(pool, relation, plan) → one SQL → JSON
+        QE->>-AC: {body, count}
+        AC->>+RN: render (JSON / CSV / singular / nulls-stripped, Content-Range)
+        RN->>-AC: conn
+    else POST / PATCH / PUT / DELETE
+        AC->>AC: Bier.Mutation.handle (INSERT/UPDATE/DELETE/upsert RETURNING)
+    else /rpc/<fn>
+        AC->>AC: Bier.Rpc.dispatch (scalar / setof / composite / void)
+    end
+    alt success
+        AC->>-G: %Plug.Conn{}
+    else error
+        AC->>FC: FallbackController.call (PGRST error envelope)
+        FC->>G: %Plug.Conn{}
+    end
+    G->>-C: response
 ```
 
-Most of the interaction mentioned in the first sequence diagram is already working, except that I'm injecting a static "DB introspection" and static responses in the _ActionController_. There are still a lot of missing pieces and unit tests, but I think the hard thing to get right would be the _QueryParser_ and _QueryExecutor_. Also, the initial goal is to support only PostgreSQL because I don't have a special interest in other adapters now. Still, if the final _QueryExecutor_ reaches a stage where we can build and execute [Ecto][] Queries, we can delegate the adapter to Ecto. But I still need some time to explore this area.
+`ActionController` resolves the target and method, runs the read/mutation/RPC
+path, and lets any non-`Plug.Conn` return value fall through to
+`Bier.Plugs.FallbackController`, which maps internal reasons and Postgres
+`SQLSTATE`s to HTTP statuses and PostgREST's `{code, message, details, hint}`
+error envelope.
 
-I'm not too worried about the initial PostgreSQL introspection because `psql` already offers a starting point. If you start the client with the option `-E` or `--echo-hidden`, that option would echo the queries generated by `\d` and other backslash commands inside `psql`.
+### The query parser
 
-Hopefully, with all this now, you have a better overview of the goals of this project.
+`Bier.QueryParser` and `Bier.QueryParser.Nimble` are **generated**,
+dependency-free modules built from `*.ex.exs` templates via `mix gen.parsers`
+(which runs `mix nimble_parsec.compile`). `nimble_parsec` is a dev-only
+dependency — the shipped code does not depend on it at runtime. Edit the
+`.ex.exs` templates and regenerate; never edit the generated `.ex` directly.
 
-That's all for now. Please feel free to reach out if you want to discuss this further.
+## Conformance
 
-Happy Hacking!
+Bier is developed against a frozen conformance suite derived from PostgREST
+**v14.12**: 532 cases spanning URL grammar, operators, select/embedding, filters,
+ordering, pagination, representations, mutations, RPC, auth, errors, headers,
+content negotiation, OpenAPI, config, observability, and domain representations.
+PostgREST is the ground truth — each case cites the exact upstream source line.
+
+Roughly 400 of the ~475 active cases pass today; most of the remainder are bound
+by the frozen test harness or the local environment rather than by Bier itself.
+The `spec/` tree (behavior models + `COVERAGE.md`) and `docs/CONFORMANCE_IMPL.md`
+document the model and the build. Known feature gaps are tracked as GitHub issues
+(observability/telemetry, schema-cache reload, admin/health endpoints, …).
+
+## Development
+
+```sh
+mix deps.get
+mix compile
+mix test            # boots a local Postgres fixture DB, then runs the suite
+mix format
+mix gen.parsers     # regenerate the parser modules after editing a *.ex.exs template
+```
+
+CI gates (run these before pushing):
+
+```sh
+mix deps.unlock --check-unused
+mix format --check-formatted
+mix hex.audit
+mix compile --warnings-as-errors
+mix docs --warnings-as-errors
+```
+
+The test suite loads `spec/conformance/fixtures.sql` into a local `bier_test`
+database; see `docs/CONFORMANCE_IMPL.md` for the database wiring.
+
+## Why "Bier"?
+
+A friend asked what this side project was. I told him it's "like an urn" 🏺 —
+a *bier* is the stand a coffin rests on. He was not amused. The name stuck. The
+real motivation is more cheerful: Elixir is my favorite language, I keep falling
+deeper into [PostgreSQL][], and serving a REST API straight from database
+introspection is a great excuse to explore both — plus [Bandit][], [Plug][],
+runtime module generation, and a parser built with [NimbleParsec][].
+
+Happy hacking!
 
 [PostgreSQL]: https://www.postgresql.org
-[PostgREST]: https://postgrest.org/en/stable/
+[PostgREST]: https://postgrest.org/en/v14/
 [Bandit]: https://github.com/mtrudel/bandit
-[NimbleParsec]: https://hexdocs.pm/nimble_parsec/NimbleParsec.html
+[Plug]: https://hexdocs.pm/plug
+[Plug.Router]: https://hexdocs.pm/plug/Plug.Router.html
 [Postgrex]: https://hexdocs.pm/postgrex/readme.html
-[Ecto]: https://hexdocs.pm/ecto
+[NimbleOptions]: https://hexdocs.pm/nimble_options
+[NimbleParsec]: https://hexdocs.pm/nimble_parsec/NimbleParsec.html


### PR DESCRIPTION
## Summary

Both `README.md` and `CLAUDE.md` described an earlier, stubbed state of the project (introspection faked, `ActionController` returning canned responses, `QueryParser`/`QueryExecutor`/auth "not yet existing"). The codebase has since grown a full request pipeline, so this brings the docs back in sync with reality.

### README.md — full technical rewrite
- Tagline + one-paragraph "how it works", installation (git dep; noted it's not yet on Hex), usage with a real `start_link/1` example and `curl` samples.
- Configuration table generated from `Bier.schema/0`, pluggable-JSON note.
- **Both mermaid sequence diagrams redrawn** to the actual flows:
  - **Boot:** `Config` → per-instance `Postgrex` pool → `HttpServerStarter` → real `Introspection` → `:persistent_term` → `RouterBuilder` → `Bandit`.
  - **Request:** catch-all `<name>.Router` → `Cors`/`Observability`/`ReadBody` → `ActionController` → optional `Bier.Auth` → `QueryParser`/`QueryExecutor`/`Render`, with the mutation and `/rpc` branches and the `FallbackController` error path.
- Architecture, generated query-parser, conformance, and development sections; the origin-story joke is kept as a short "Why Bier?" blurb.

### CLAUDE.md — corrected stale sections
- **Project status:** no longer "stubbed/canned/doesn't exist."
- **Boot sequence:** three children + ordering, real introspection, `:persistent_term`, `compress: false`.
- **Router:** thin catch-all + fixed plug pipeline (per-table `get/post/delete` routes are gone).
- **Controllers → request pipeline:** target resolution, inline auth, dispatch table; added a generated-parser section.
- **Common commands / Test layout:** `mix test` boots the fixture DB; the conformance suite and the frozen `test/**` + `spec/**` rule.

## Notes
- Docs-only change; no `lib/` touched.
- The README's intra-doc anchor links (e.g. `#conformance`) are fine — ExDoc isn't configured with `extras`, so the README isn't processed by the `mix docs --warnings-as-errors` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)