### PR TITLE
feat(observability): emit initial :telemetry events (closes #26)

### DIFF
--- a/lib/bier/http_server_starter.ex
+++ b/lib/bier/http_server_starter.ex
@@ -11,9 +11,19 @@ defmodule Bier.HttpServerStarter do
   @impl GenServer
   def init(%Bier.Config{name: name, db_schemas: schemas} = conf) do
     conn = Bier.Registry.via(name, Postgrex)
-    relations = Bier.Introspection.run(conn, schemas)
-    functions = Bier.Introspection.functions(conn, schemas)
-    media_handlers = Bier.Introspection.media_handlers(conn, schemas)
+
+    # The DB introspection that builds the in-memory schema cache is wrapped in a
+    # `[:bier, :schema_cache, :load, *]` telemetry span (per instance), so host
+    # apps can track load duration and the relation count (and catch failures
+    # via the span's `:exception` event).
+    {relations, functions, media_handlers} =
+      Bier.Telemetry.schema_cache_load(%{instance: name, schemas: schemas}, fn ->
+        relations = Bier.Introspection.run(conn, schemas)
+        functions = Bier.Introspection.functions(conn, schemas)
+        media_handlers = Bier.Introspection.media_handlers(conn, schemas)
+
+        {{relations, functions, media_handlers}, %{relation_count: map_size(relations)}}
+      end)
 
     # The request pipeline resolves {schema, relation} on every request, so the
     # introspection map is stashed in :persistent_term (read-mostly) keyed by the

--- a/lib/bier/plugs/action_controller.ex
+++ b/lib/bier/plugs/action_controller.ex
@@ -61,6 +61,7 @@ defmodule Bier.Plugs.ActionController do
           {:ok, schema, content_profile} ->
             with {:ok, conn} <- maybe_auth(conn, config, schema) do
               conn = maybe_content_profile(conn, content_profile)
+              conn = assign(conn, :bier_target, {schema, fn_name})
               Bier.Rpc.dispatch(conn, config, {:ok, schema}, fn_name)
             end
 
@@ -204,6 +205,9 @@ defmodule Bier.Plugs.ActionController do
          conn = maybe_content_profile(conn, content_profile),
          :ok <- reject_openapi_media(conn),
          {:ok, relation} <- resolve_relation(conn, schema, relations) do
+      # Tag the resolved target so the observability span (`:bier_target`) can
+      # report schema/relation on `[:bier, :request, :stop]`.
+      conn = assign(conn, :bier_target, {relation.schema, relation.name})
       handle(conn.method, conn, config, relation)
     end
   end

--- a/lib/bier/plugs/observability.ex
+++ b/lib/bier/plugs/observability.ex
@@ -33,12 +33,40 @@ defmodule Bier.Plugs.Observability do
 
   @impl Plug
   def call(conn, _opts) do
-    config = Registry.config(conn.assigns.supervisor_name)
+    name = conn.assigns.supervisor_name
+    config = Registry.config(name)
     start = System.monotonic_time(:native)
+
+    # `[:bier, :request, :start]` fires here; `:stop` fires in a before_send
+    # callback so its duration is the real request wall-clock. The span is keyed
+    # by the instance name (a node can host several Bier instances).
+    request_start = Bier.Telemetry.request_start(request_metadata(conn, name))
 
     conn
     |> echo_trace_header(config)
     |> register_before_send(&put_server_timing(&1, config, start))
+    |> register_before_send(&emit_request_stop(&1, name, request_start))
+  end
+
+  # ---- request span --------------------------------------------------------
+
+  defp request_metadata(conn, name) do
+    %{instance: name, method: conn.method, route: conn.request_path}
+  end
+
+  # The `{schema, relation}` target is stashed in `:bier_target` by
+  # `Bier.Plugs.ActionController` once resolved; it is `nil` for the root
+  # document, OPTIONS, and responses that error before resolving a relation.
+  defp emit_request_stop(conn, name, request_start) do
+    {schema, relation} = conn.assigns[:bier_target] || {nil, nil}
+
+    metadata =
+      conn
+      |> request_metadata(name)
+      |> Map.merge(%{status: conn.status, schema: schema, relation: relation})
+
+    Bier.Telemetry.request_stop(request_start, metadata)
+    conn
   end
 
   # ---- trace header --------------------------------------------------------

--- a/lib/bier/telemetry.ex
+++ b/lib/bier/telemetry.ex
@@ -1,0 +1,115 @@
+defmodule Bier.Telemetry do
+  @moduledoc """
+  `:telemetry` events emitted by Bier.
+
+  Bier follows the idiomatic Elixir observability path: it emits `:telemetry`
+  events and leaves it to the host application to attach `Telemetry.Metrics` /
+  a reporter (Prometheus, StatsD, …). Nothing is exported in-process.
+
+  Because a single BEAM node can host several Bier instances at once — each its
+  own database, config, and HTTP server (see `Bier`) — **every event carries the
+  originating instance name under `:instance` in its metadata**. Attach with
+  `:telemetry.attach/4` (or `attach_many/4`) and filter on `metadata.instance`
+  to scope metrics to one instance.
+
+  ## Events
+
+  ### `[:bier, :request, :start]`
+
+  Emitted when a request enters the pipeline (`Bier.Plugs.Observability`).
+
+    * Measurements: `:system_time`, `:monotonic_time`.
+    * Metadata: `:instance`, `:method`, `:route` (the request path).
+
+  ### `[:bier, :request, :stop]`
+
+  Emitted when the response is sent (a `Plug.Conn.register_before_send/2`
+  callback), so the duration is the real request wall-clock.
+
+    * Measurements: `:duration` (native time units), `:monotonic_time`.
+    * Metadata: `:instance`, `:method`, `:route`, `:status`, plus `:schema` and
+      `:relation` once the target has been resolved (both `nil` for the root
+      document, `OPTIONS`, and error responses that never resolve a relation).
+
+  > #### Per-phase timings {: .info}
+  > These events carry only the **total** request duration. The per-phase
+  > splits (jwt / parse / plan / transaction / response) that `Server-Timing`
+  > reports are still fabricated today; threading real per-phase timings through
+  > the pipeline is tracked as the Server-Timing fidelity follow-up (#26).
+
+  ### `[:bier, :schema_cache, :load, :start | :stop | :exception]`
+
+  A `:telemetry.span/3` around boot-time DB introspection
+  (`Bier.HttpServerStarter`). The `:stop` event marks a successful load; a
+  failing introspection emits `:exception` instead (the "fail" status, mirroring
+  PostgREST's `pgrst_schema_cache_loads_total{status="fail"}`).
+
+    * `:start` metadata: `:instance`, `:schemas`.
+    * `:stop` measurements: `:duration`; metadata: `:instance`, `:schemas`,
+      `:status` (`:ok`), `:relation_count`.
+    * `:exception` carries the standard `:kind`, `:reason`, `:stacktrace`
+      alongside `:instance` and `:schemas`.
+
+  ## Not yet emitted
+
+  Two further families from #26 depend on infrastructure Bier does not have yet
+  and are tracked as a follow-up:
+
+    * `[:bier, :pool, …]` — Postgrex/DBConnection pool gauges (no clean public
+      API to poll pool size/queue today).
+    * `[:bier, :jwt_cache, …]` — Bier verifies every JWT directly; there is no
+      verification cache to instrument.
+  """
+
+  @request_start [:bier, :request, :start]
+  @request_stop [:bier, :request, :stop]
+  @schema_cache_load [:bier, :schema_cache, :load]
+
+  @doc """
+  Emit `[:bier, :request, :start]` and return the monotonic start time to hand
+  back to `request_stop/2` when the response is sent.
+  """
+  @spec request_start(map()) :: integer()
+  def request_start(metadata) do
+    start = System.monotonic_time()
+
+    :telemetry.execute(
+      @request_start,
+      %{system_time: System.system_time(), monotonic_time: start},
+      metadata
+    )
+
+    start
+  end
+
+  @doc """
+  Emit `[:bier, :request, :stop]`, computing `:duration` from the `start` value
+  returned by `request_start/1`.
+  """
+  @spec request_stop(integer(), map()) :: :ok
+  def request_stop(start, metadata) do
+    stop = System.monotonic_time()
+
+    :telemetry.execute(
+      @request_stop,
+      %{duration: stop - start, monotonic_time: stop},
+      metadata
+    )
+  end
+
+  @doc """
+  Wrap a schema-cache load in a `[:bier, :schema_cache, :load, *]` span.
+
+  `fun` must return `{result, stop_metadata}`; `result` is returned to the
+  caller and `stop_metadata` (e.g. `%{relation_count: n}`) is merged with the
+  start `metadata` and `status: :ok` for the `:stop` event. A raise inside `fun`
+  surfaces as the `:exception` event.
+  """
+  @spec schema_cache_load(map(), (-> {result, map()})) :: result when result: var
+  def schema_cache_load(metadata, fun) when is_function(fun, 0) do
+    :telemetry.span(@schema_cache_load, metadata, fn ->
+      {result, stop_metadata} = fun.()
+      {result, metadata |> Map.put(:status, :ok) |> Map.merge(stop_metadata)}
+    end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -66,6 +66,7 @@ defmodule Bier.MixProject do
       {:nimble_parsec, "~> 1.4", only: :dev, runtime: false},
       {:plug, "~> 1.19"},
       {:postgrex, "~> 0.20"},
+      {:telemetry, "~> 1.0"},
       {:req, "~> 0.5", only: :test},
       {:yaml_elixir, "~> 2.11", only: :test}
     ]

--- a/test/bier/telemetry_test.exs
+++ b/test/bier/telemetry_test.exs
@@ -1,0 +1,136 @@
+defmodule Bier.TelemetryTest do
+  @moduledoc """
+  Exercises the `:telemetry` events Bier emits (#26).
+
+  Each test boots its own short-lived Bier instance (a fresh DB introspection +
+  Bandit server) and attaches a handler that only forwards events whose
+  `metadata.instance` matches that instance's name. Because multiple Bier
+  instances can run in one node, every event carries its originating instance
+  name — these tests both rely on and verify that.
+  """
+  use ExUnit.Case, async: false
+
+  # ---- request span --------------------------------------------------------
+
+  test "a request emits [:bier, :request, :start | :stop] tagged with the instance" do
+    name = unique_name()
+    {base, _pid} = start_listening_instance(name)
+
+    ref = attach([[:bier, :request, :start], [:bier, :request, :stop]], name)
+
+    resp = Req.get!(base <> "/items", retry: false)
+    assert resp.status == 200
+
+    assert_receive {^ref, [:bier, :request, :start], start_meas, start_meta}
+    assert %{system_time: _, monotonic_time: _} = start_meas
+    assert %{instance: ^name, method: "GET", route: "/items"} = start_meta
+
+    assert_receive {^ref, [:bier, :request, :stop], stop_meas, stop_meta}
+    assert %{duration: duration} = stop_meas
+    assert duration > 0
+
+    assert %{
+             instance: ^name,
+             method: "GET",
+             route: "/items",
+             status: 200,
+             schema: "test",
+             relation: "items"
+           } = stop_meta
+  end
+
+  # ---- schema-cache load span ----------------------------------------------
+
+  test "boot emits [:bier, :schema_cache, :load, :start | :stop] with a relation count" do
+    name = unique_name()
+
+    # Attach BEFORE boot: the load span fires synchronously inside the instance's
+    # startup, so the handler must already be in place to observe it.
+    ref =
+      attach([[:bier, :schema_cache, :load, :start], [:bier, :schema_cache, :load, :stop]], name)
+
+    {:ok, pid} = start_instance(name)
+    on_exit(fn -> stop(pid) end)
+
+    assert_receive {^ref, [:bier, :schema_cache, :load, :start], _start_meas, start_meta}
+    assert %{instance: ^name, schemas: schemas} = start_meta
+    assert is_list(schemas) and schemas != []
+
+    assert_receive {^ref, [:bier, :schema_cache, :load, :stop], stop_meas, stop_meta}
+    assert %{duration: duration} = stop_meas
+    assert duration > 0
+    assert %{instance: ^name, status: :ok, relation_count: relation_count} = stop_meta
+    assert relation_count > 0
+  end
+
+  # ---- helpers -------------------------------------------------------------
+
+  defp unique_name do
+    Module.concat(__MODULE__, "I#{System.unique_integer([:positive])}")
+  end
+
+  # Attach a handler forwarding the given events to the test process, but only
+  # those originating from `name` so concurrent suites never bleed in. A captured
+  # module function (not a closure) keeps telemetry from logging a perf warning.
+  defp attach(events, name) do
+    ref = make_ref()
+    handler_id = {__MODULE__, ref}
+    config = %{pid: self(), ref: ref, name: name}
+
+    :telemetry.attach_many(handler_id, events, &__MODULE__.forward/4, config)
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    ref
+  end
+
+  @doc false
+  def forward(event, measurements, metadata, %{pid: pid, ref: ref, name: name}) do
+    if metadata[:instance] == name, do: send(pid, {ref, event, measurements, metadata})
+  end
+
+  defp start_instance(name) do
+    port = free_port()
+
+    Bier.start_link(
+      [name: name, router: [port: port, scheme: :http]] ++ Bier.ConformanceServer.base_opts()
+    )
+  end
+
+  defp start_listening_instance(name) do
+    {:ok, pid} = start_instance(name)
+    on_exit(fn -> stop(pid) end)
+    port = Bier.Registry.config(name).router[:port]
+    wait_until_listening(port)
+    {"http://127.0.0.1:#{port}", pid}
+  end
+
+  # The instance supervisor is linked to the test process, so it may already be
+  # terminating by the time this on_exit cleanup runs; `Supervisor.stop/1` then
+  # exits rather than raising. Swallow both so cleanup never fails the test.
+  defp stop(pid) do
+    if Process.alive?(pid), do: Supervisor.stop(pid)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp free_port do
+    {:ok, sock} = :gen_tcp.listen(0, [:binary, ip: {127, 0, 0, 1}])
+    {:ok, port} = :inet.port(sock)
+    :gen_tcp.close(sock)
+    port
+  end
+
+  defp wait_until_listening(port, retries \\ 100) do
+    case :gen_tcp.connect(~c"127.0.0.1", port, [], 10) do
+      {:ok, sock} ->
+        :gen_tcp.close(sock)
+        :ok
+
+      {:error, _} when retries > 0 ->
+        Process.sleep(20)
+        wait_until_listening(port, retries - 1)
+
+      {:error, reason} ->
+        raise "instance did not come up on port #{port}: #{inspect(reason)}"
+    end
+  end
+end


### PR DESCRIPTION
## What

Implements the `:telemetry` event surface from #26 — the Elixir-native
counterpart to PostgREST's Prometheus metrics. Host apps can now attach
`Telemetry.Metrics` / a reporter; nothing is exported in-process.

Scoped (per discussion on #26) to the two families that map cleanly onto
existing code paths, with **total-duration** timing and **per-instance**
metadata:

| Event | Measurements | Metadata |
|---|---|---|
| `[:bier, :request, :start]` | `system_time`, `monotonic_time` | `instance`, `method`, `route` |
| `[:bier, :request, :stop]` | `duration`, `monotonic_time` | `instance`, `method`, `route`, `status`, `schema`, `relation` |
| `[:bier, :schema_cache, :load, :start \| :stop \| :exception]` | `duration` (stop) | `instance`, `schemas`, `status`, `relation_count` |

Every event carries the originating instance name under `:instance`, since a
node can host multiple Bier instances (distinct DB/config each).

## Changes

- **`mix.exs`** — `:telemetry` promoted to an explicit runtime dep (already
  present transitively at 1.4.1; `mix.lock` unchanged).
- **`lib/bier/telemetry.ex`** (new) — documented event catalog + emit helpers
  (`request_start/1`, `request_stop/2`, `schema_cache_load/2` via
  `:telemetry.span/3`).
- **`lib/bier/plugs/observability.ex`** — emits request `:start` on entry and
  `:stop` in a `before_send` callback (real wall-clock).
- **`lib/bier/plugs/action_controller.ex`** — stashes the resolved
  `{schema, relation}` in `conn.assigns[:bier_target]` so `:stop` can report it.
  No response behavior changes.
- **`lib/bier/http_server_starter.ex`** — wraps boot-time introspection in the
  schema-cache span.
- **`test/bier/telemetry_test.exs`** (new) — TDD tests (written failing first)
  asserting both spans fire with correct measurements + per-instance metadata.

## Deferred

- **Per-phase request timings** (jwt/parse/plan/transaction) — not threaded;
  Server-Timing keeps its fabricated split (the Server-Timing fidelity
  follow-up in #26).
- **`[:bier, :pool, …]`** and **`[:bier, :jwt_cache, …]`** — need subsystems
  Bier lacks today (a pool poller; a JWT verification cache). Tracked in #36.
- `:request.exception` is not emitted from the plug: Bier's handled errors flow
  through `send_resp` (so they get a `:stop` with the right status), and true
  crashes are covered by Bandit's own telemetry. The schema-cache span does emit
  `:exception` on a failed load.

## Verification

- New telemetry tests: 2/2 pass.
- Gates clean: `deps.unlock --check-unused`, `format --check-formatted`,
  `hex.audit`, `compile --warnings-as-errors`, `docs --warnings-as-errors`.
- Full suite: the only failures (1467 RS256, 1616–1618 geojson) are
  **pre-existing** — verified identical on the stashed baseline. Zero
  regressions.

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)