### PR TITLE
feat(#30): admin health endpoints /live and /ready

### DIFF
--- a/docs/superpowers/plans/2026-06-07-admin-health-endpoints.md
+++ b/docs/superpowers/plans/2026-06-07-admin-health-endpoints.md
@@ -1,0 +1,541 @@
+# Admin health endpoints (`/live`, `/ready`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in, per-instance admin HTTP server exposing `GET /live` and `GET /ready`, plus the `admin-server-port` ≠ `server-port` validation (issue #30).
+
+**Architecture:** Each `Bier` supervisor instance optionally starts a second Bandit listener (bound to `admin_server_port`) serving a dedicated minimal plug `Bier.Plugs.AdminRouter` — separate from the catch-all API router so root URLs stay PostgREST-compatible. `/live` is pure liveness; `/ready` delegates to `Bier.Health.ready?/1`, which checks the instance's schema cache (`:persistent_term`) and pings its Postgrex pool.
+
+**Tech Stack:** Elixir 1.19 / OTP 28, Plug, Bandit, Postgrex, NimbleOptions, ExUnit, Req (test HTTP client).
+
+---
+
+## File structure
+
+- **Modify** `lib/bier.ex` — add `admin_server_port` to the options schema; start the admin Bandit listener in `init/1` when the port is set.
+- **Modify** `lib/bier/config.ex` — add `admin_server_port` to the struct + typespec; cross-field validation in `new!/2`.
+- **Create** `lib/bier/health.ex` — `Bier.Health.ready?/1` (schema-cache + DB-ping check).
+- **Create** `lib/bier/plugs/admin_router.ex` — `Bier.Plugs.AdminRouter` plug (`/live`, `/ready`, 404 fallthrough).
+- **Create** `test/bier/health_test.exs` — unit test for the cache-absent readiness path.
+- **Create** `test/bier/plugs/admin_router_test.exs` — unit tests for the plug (`/live` 200, `/ready` 503 when not ready, 404).
+- **Create** `test/bier/admin_server_test.exs` — integration test: boot an instance with an admin port, hit `/live` and `/ready` over HTTP.
+- **Modify** `test/bier_test.exs` — config validation unit tests (admin == server port rejected).
+- **Modify** `spec/COVERAGE.md` — update the `admin_server` note.
+
+---
+
+## Task 1: Config — `admin_server_port` field + cross-field validation
+
+**Files:**
+- Modify: `lib/bier.ex` (schema list, end of `schema/0`)
+- Modify: `lib/bier/config.ex` (typespec, `defstruct`, `new!/2`)
+- Test: `test/bier_test.exs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the contents of `test/bier_test.exs` with:
+
+```elixir
+defmodule BierTest do
+  use ExUnit.Case, async: true
+
+  describe "Bier.Config.new!/2 admin-server-port validation" do
+    defp opts(extra), do: [name: :"admin_cfg_#{System.unique_integer([:positive])}"] ++ extra
+
+    test "rejects admin_server_port equal to the router port" do
+      assert_raise ArgumentError, ~r/admin-server-port cannot be the same as server-port/, fn ->
+        Bier.Config.new!(
+          opts(router: [port: 3000, scheme: :http], admin_server_port: 3000),
+          Bier.schema()
+        )
+      end
+    end
+
+    test "accepts admin_server_port that differs from the router port" do
+      conf =
+        Bier.Config.new!(
+          opts(router: [port: 3000, scheme: :http], admin_server_port: 3001),
+          Bier.schema()
+        )
+
+      assert conf.admin_server_port == 3001
+    end
+
+    test "accepts a nil admin_server_port (default, admin server disabled)" do
+      conf = Bier.Config.new!(opts(router: [port: 3000, scheme: :http]), Bier.schema())
+      assert conf.admin_server_port == nil
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `mix test test/bier_test.exs`
+Expected: FAIL — `admin_server_port` is not yet a known option / not on the struct (e.g. `NimbleOptions` "unknown options" or `KeyError`).
+
+- [ ] **Step 3: Add the schema option**
+
+In `lib/bier.ex`, inside `schema/0`, add this entry immediately after the `db_root_spec:` entry (before the closing `]` of the list):
+
+```elixir
+      ],
+      admin_server_port: [
+        type: {:or, [:pos_integer, nil]},
+        default: env(:admin_server_port, nil),
+        doc: """
+        TCP port for the per-instance admin server exposing the `/live` and
+        `/ready` health endpoints (PostgREST admin-server-port). When `nil`
+        (the default) no admin server starts. Must differ from `router[:port]`.
+        """
+      ]
+    ]
+  end
+```
+
+(Note: the snippet shows the `db_root_spec` entry's closing `],` followed by the new entry and the list/`schema/0` close. Adjust to match the existing closing punctuation — append a `,` after the `db_root_spec` entry's `]` and insert the new entry.)
+
+- [ ] **Step 4: Add the struct field + typespec**
+
+In `lib/bier/config.ex`, add to the `@type t` map (after `db_root_spec: String.t() | nil`):
+
+```elixir
+          db_root_spec: String.t() | nil,
+          admin_server_port: pos_integer() | nil
+        }
+```
+
+And add `:admin_server_port` to `defstruct` (it defaults to `nil`, so add it to the leading list of bare atoms, e.g. next to `:db_root_spec`):
+
+```elixir
+    :db_root_spec,
+    :admin_server_port,
+```
+
+- [ ] **Step 5: Add cross-field validation in `new!/2`**
+
+In `lib/bier/config.ex`, replace `new!/2` with:
+
+```elixir
+  @spec new!(Keyword.t(), Keyword.t()) :: t() | no_return()
+  def new!(opts, schema) do
+    conf = NimbleOptions.validate!(opts, schema)
+
+    validate_admin_server_port!(conf)
+
+    struct!(__MODULE__, conf)
+  end
+
+  # PostgREST rejects an admin-server-port equal to server-port at startup
+  # (test_cli.py:test_server_port_and_admin_port_same_value; conformance case
+  # 1717). NimbleOptions validates fields independently, so this cross-field
+  # check lives here.
+  defp validate_admin_server_port!(conf) do
+    admin_port = conf[:admin_server_port]
+    server_port = get_in(conf, [:router, :port])
+
+    if not is_nil(admin_port) and admin_port == server_port do
+      raise ArgumentError, "admin-server-port cannot be the same as server-port"
+    end
+  end
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `mix test test/bier_test.exs`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/bier.ex lib/bier/config.ex test/bier_test.exs
+git commit -m "feat(#30): admin_server_port config + server-port collision validation"
+```
+
+---
+
+## Task 2: `Bier.Health` readiness check
+
+**Files:**
+- Create: `lib/bier/health.ex`
+- Test: `test/bier/health_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/bier/health_test.exs`:
+
+```elixir
+defmodule Bier.HealthTest do
+  use ExUnit.Case, async: true
+
+  describe "ready?/1" do
+    test "is false when the schema cache is absent (no DB ping needed)" do
+      # An instance name that was never booted has no :persistent_term relations
+      # entry and no Postgrex pool. ready?/1 must short-circuit to false on the
+      # empty cache without raising on the missing pool.
+      name = :"never_booted_#{System.unique_integer([:positive])}"
+      refute Bier.Health.ready?(name)
+    end
+
+    test "is false when the schema cache is present but empty" do
+      name = :"empty_cache_#{System.unique_integer([:positive])}"
+      :persistent_term.put({Bier, :relations, name}, %{})
+      on_exit(fn -> :persistent_term.erase({Bier, :relations, name}) end)
+      refute Bier.Health.ready?(name)
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/health_test.exs`
+Expected: FAIL — `Bier.Health` is undefined.
+
+- [ ] **Step 3: Implement `Bier.Health`**
+
+Create `lib/bier/health.ex`:
+
+```elixir
+defmodule Bier.Health do
+  @moduledoc """
+  Health checks backing the per-instance admin endpoints.
+
+  `ready?/1` reports whether a named `Bier` instance can serve requests: its
+  schema cache must be populated AND its Postgrex pool must answer a trivial
+  query. The schema-cache check runs first and short-circuits, so a name with no
+  cache returns `false` without touching (a possibly absent) connection pool.
+  """
+
+  alias Bier.Registry
+
+  @doc """
+  Returns `true` when the instance `name` is ready to serve requests:
+  the schema cache is populated and the database answers `SELECT 1`.
+  """
+  @spec ready?(Bier.name()) :: boolean()
+  def ready?(name) do
+    schema_cache_populated?(name) and database_responsive?(name)
+  end
+
+  defp schema_cache_populated?(name) do
+    map_size(:persistent_term.get({Bier, :relations, name}, %{})) > 0
+  end
+
+  defp database_responsive?(name) do
+    case Postgrex.query(Registry.via(name, Postgrex), "SELECT 1", []) do
+      {:ok, _result} -> true
+      {:error, _reason} -> false
+    end
+  rescue
+    _ -> false
+  catch
+    :exit, _ -> false
+  end
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/health_test.exs`
+Expected: PASS (2 tests). The empty/absent cache short-circuits before the pool lookup.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/bier/health.ex test/bier/health_test.exs
+git commit -m "feat(#30): Bier.Health.ready?/1 schema-cache + DB-ping check"
+```
+
+---
+
+## Task 3: `Bier.Plugs.AdminRouter` plug
+
+**Files:**
+- Create: `lib/bier/plugs/admin_router.ex`
+- Test: `test/bier/plugs/admin_router_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/bier/plugs/admin_router_test.exs`:
+
+```elixir
+defmodule Bier.Plugs.AdminRouterTest do
+  use ExUnit.Case, async: true
+  import Plug.Test
+  import Plug.Conn
+
+  alias Bier.Plugs.AdminRouter
+
+  defp call(method, path, name) do
+    conn(method, path)
+    |> AdminRouter.call(AdminRouter.init(name: name))
+  end
+
+  test "GET /live returns 200 regardless of readiness" do
+    name = :"live_#{System.unique_integer([:positive])}"
+    conn = call(:get, "/live", name)
+    assert conn.status == 200
+  end
+
+  test "GET /ready returns 503 when the instance is not ready" do
+    # No schema cache for this name -> Bier.Health.ready?/1 is false.
+    name = :"notready_#{System.unique_integer([:positive])}"
+    conn = call(:get, "/ready", name)
+    assert conn.status == 503
+  end
+
+  test "unknown paths return 404" do
+    name = :"unknown_#{System.unique_integer([:positive])}"
+    assert call(:get, "/metrics", name).status == 404
+    assert call(:post, "/live", name).status == 404
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/plugs/admin_router_test.exs`
+Expected: FAIL — `Bier.Plugs.AdminRouter` is undefined.
+
+- [ ] **Step 3: Implement the plug**
+
+Create `lib/bier/plugs/admin_router.ex`:
+
+```elixir
+defmodule Bier.Plugs.AdminRouter do
+  @moduledoc """
+  Minimal plug for a `Bier` instance's admin server (PostgREST admin server).
+
+  Served on its own Bandit listener bound to `admin_server_port`, kept separate
+  from the catch-all API router so the health paths never collide with table
+  names. Exposes:
+
+    * `GET /live`  — `200` whenever the process is up (pure liveness).
+    * `GET /ready` — `200` when `Bier.Health.ready?/1` holds, else `503`.
+
+  Every other request returns `404`. The instance name is supplied via
+  `init/1` (`name:`) so readiness resolves the right pool and schema cache.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl Plug
+  def init(opts), do: Keyword.fetch!(opts, :name)
+
+  @impl Plug
+  def call(%Plug.Conn{method: "GET", path_info: ["live"]} = conn, _name) do
+    send_resp(conn, 200, "")
+  end
+
+  def call(%Plug.Conn{method: "GET", path_info: ["ready"]} = conn, name) do
+    status = if Bier.Health.ready?(name), do: 200, else: 503
+    send_resp(conn, status, "")
+  end
+
+  def call(conn, _name) do
+    send_resp(conn, 404, "")
+  end
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/plugs/admin_router_test.exs`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/bier/plugs/admin_router.ex test/bier/plugs/admin_router_test.exs
+git commit -m "feat(#30): Bier.Plugs.AdminRouter with /live and /ready"
+```
+
+---
+
+## Task 4: Wire the admin Bandit listener into the supervisor + integration test
+
+**Files:**
+- Modify: `lib/bier.ex` (`init/1`)
+- Test: `test/bier/admin_server_test.exs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `test/bier/admin_server_test.exs`:
+
+```elixir
+defmodule Bier.AdminServerTest do
+  @moduledoc """
+  Boots a dedicated Bier instance with an admin server against the test DB and
+  exercises the health endpoints over HTTP. Not async: it binds real ports and
+  runs DB introspection at boot.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :integration
+
+  setup do
+    api_port = free_port()
+    admin_port = free_port()
+
+    opts =
+      [
+        name: :"admin_it_#{System.unique_integer([:positive])}",
+        router: [port: api_port, scheme: :http],
+        admin_server_port: admin_port
+      ] ++ Bier.ConformanceServer.base_opts()
+
+    start_supervised!({Bier, opts})
+    wait_until_listening(admin_port)
+
+    %{admin_port: admin_port}
+  end
+
+  test "GET /live returns 200", %{admin_port: admin_port} do
+    resp = Req.get!("http://127.0.0.1:#{admin_port}/live", retry: false)
+    assert resp.status == 200
+  end
+
+  test "GET /ready returns 200 once the schema cache is populated", %{admin_port: admin_port} do
+    resp = Req.get!("http://127.0.0.1:#{admin_port}/ready", retry: false)
+    assert resp.status == 200
+  end
+
+  test "unknown admin paths return 404", %{admin_port: admin_port} do
+    resp = Req.get!("http://127.0.0.1:#{admin_port}/nope", retry: false)
+    assert resp.status == 404
+  end
+
+  defp free_port do
+    {:ok, sock} = :gen_tcp.listen(0, [:binary, ip: {127, 0, 0, 1}])
+    {:ok, port} = :inet.port(sock)
+    :gen_tcp.close(sock)
+    port
+  end
+
+  defp wait_until_listening(port, retries \\ 100) do
+    case :gen_tcp.connect(~c"127.0.0.1", port, [], 10) do
+      {:ok, sock} ->
+        :gen_tcp.close(sock)
+        :ok
+
+      {:error, _} when retries > 0 ->
+        Process.sleep(20)
+        wait_until_listening(port, retries - 1)
+
+      {:error, reason} ->
+        raise "admin server did not come up on port #{port}: #{inspect(reason)}"
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/admin_server_test.exs`
+Expected: FAIL — no admin server is started, so `wait_until_listening/1` raises (nothing binds `admin_port`).
+
+- [ ] **Step 3: Start the admin listener in `init/1`**
+
+In `lib/bier.ex`, change `init/1` so its `children` list appends the admin children, and add the `admin_children/1` helper. Replace the existing `init/1` body's `children = [...]` assignment with one that appends `admin_children(conf)`:
+
+```elixir
+  @impl Supervisor
+  def init(%Bier.Config{name: name} = conf) do
+    children =
+      [
+        Supervisor.child_spec({Postgrex, postgrex_opts(conf)}, id: {name, Postgrex}),
+        {DynamicSupervisor,
+         strategy: :one_for_one, name: Registry.via(conf.name, DynamicSupervisor)},
+        {Bier.HttpServerStarter, conf}
+      ] ++ admin_children(conf)
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  # When `admin_server_port` is set, run a second Bandit listener serving the
+  # admin health endpoints (separate from the API router). Started statically
+  # here (it needs no introspection result); `/ready` reports 503 until the
+  # schema cache is populated, which is the correct readiness signal.
+  defp admin_children(%Bier.Config{admin_server_port: nil}), do: []
+
+  defp admin_children(%Bier.Config{name: name, admin_server_port: port} = conf) do
+    [
+      Supervisor.child_spec(
+        {Bandit,
+         scheme: conf.router[:scheme],
+         plug: {Bier.Plugs.AdminRouter, name: name},
+         port: port,
+         http_options: [compress: false]},
+        id: {name, :admin_server}
+      )
+    ]
+  end
+```
+
+(Keep the existing explanatory comments on the Postgrex/DynamicSupervisor children — only the `children =` assignment shape and the new helper change.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/admin_server_test.exs`
+Expected: PASS (3 tests). Requires a reachable test DB (same as the conformance suite).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/bier.ex test/bier/admin_server_test.exs
+git commit -m "feat(#30): start per-instance admin server when admin_server_port set"
+```
+
+---
+
+## Task 5: Documentation + full-suite verification
+
+**Files:**
+- Modify: `spec/COVERAGE.md`
+
+- [ ] **Step 1: Update the `admin_server` coverage note**
+
+In `spec/COVERAGE.md`, find the `admin_server` row (currently):
+
+```
+| `admin_server` (Admin Server) | 1717 (admin-port = server-port fatal) | Only the port-collision validation. Partial — no `/live` `/ready` health-endpoint case. |
+```
+
+Replace its third column with:
+
+```
+| `admin_server` (Admin Server) | 1717 (admin-port = server-port fatal) | Port-collision validation (case 1717, library-enforced in `Bier.Config`) plus `/live`/`/ready` covered by ExUnit (`test/bier/admin_server_test.exs`). Partial — case 1717 stays `:pending` (CLI `--dump-config`), `/metrics` not yet implemented. |
+```
+
+- [ ] **Step 2: Run the format + compile gates**
+
+Run:
+```bash
+mix format
+mix compile --warnings-as-errors
+```
+Expected: no errors, no warnings.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `mix test`
+Expected: the 6 pre-existing DB-fixture/auth conformance failures remain (unchanged baseline), and the new tests (Tasks 1–4) all PASS — total failures must not exceed the baseline 6.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spec/COVERAGE.md
+git commit -m "docs(#30): record /live /ready coverage in COVERAGE.md"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** Config field + default nil (Task 1), admin≠server validation with case-1717 wording (Task 1), separate Bandit listener under the supervisor (Task 4), `/live` 200 (Tasks 3/4), `/ready` DB-ping + schema-cache → 200/503 (Tasks 2/3/4), COVERAGE.md note (Task 5). All design sections map to a task.
+- **Placeholder scan:** none — every code/test step shows full content.
+- **Type/name consistency:** `Bier.Health.ready?/1`, `Bier.Plugs.AdminRouter.init/1` (`name:`)/`call/2`, `admin_server_port`, cache key `{Bier, :relations, name}`, and `Registry.via(name, Postgrex)` are used identically across tasks and match the existing codebase.
+- **Out of scope (unchanged):** `/metrics`, CLI `--dump-config` runner, TLS for the admin listener.

--- a/docs/superpowers/specs/2026-06-07-admin-health-endpoints-design.md
+++ b/docs/superpowers/specs/2026-06-07-admin-health-endpoints-design.md
@@ -1,0 +1,125 @@
+# Admin health endpoints (`/live`, `/ready`) — Design
+
+**Issue:** #30 — `[feature] Admin health endpoints /live and /ready`
+**Date:** 2026-06-07
+**Status:** Approved (brainstorming)
+
+## Summary
+
+PostgREST exposes an admin server (on `admin-server-port`) with health
+endpoints `/live` and `/ready`. Bier has none. This adds a per-instance admin
+HTTP server with `GET /live` and `GET /ready`, opt-in via a new
+`admin_server_port` config field, plus the `admin-server-port` ≠ `server-port`
+validation (the library-level enforcement that conformance case `1717` mirrors).
+
+## Why this differs from PostgREST (the key decision)
+
+PostgREST is one DB per process, so it has one admin server. Bier serves
+**multiple DBs at once — one DB per `Bier` supervisor instance**, each with its
+own `Bier.Config`. Health is therefore **inherently per-instance**: readiness is
+computed against *that instance's* connection pool and *that instance's* schema
+cache.
+
+Three layouts were considered:
+
+- **A — per-instance admin port (chosen).** Each instance gets its own
+  `admin_server_port` → its own small Bandit listener serving only `/live` and
+  `/ready`. Clean admin/API split, separately firewall-able, PostgREST-compatible
+  root URLs preserved. Falls out naturally from the per-instance config model.
+- **B — same port, reserved paths.** Reserve `/live` `/ready` on the main router
+  so they shadow tables. Rejected: a table literally named `live`/`ready`
+  becomes unreachable, the admin surface is publicly exposed, diverges from
+  PostgREST.
+- **C — namespace the API under `/api/`.** Rejected: Bier's reason for existing
+  is **PostgREST conformance**; PostgREST serves resources at the root
+  (`GET /tablename`, `GET /rpc/fn`, `GET /` for OpenAPI), and the whole
+  `spec/conformance/` suite hits root paths. An `/api/` prefix would break URL
+  parity and invalidate conformance, while still giving no ops separation.
+
+**Namespace-collision detail that drives A:** `Bier.RouterBuilder.build/2`
+produces a pure catch-all router — every request is handed to
+`Bier.Plugs.ActionController`, which resolves the path to a `{schema, relation}`
+lookup. So on the main port `GET /live` would be interpreted as a lookup for a
+relation named `live`. A separate admin port avoids the collision entirely.
+
+## Components
+
+### 1. Config (`lib/bier.ex`, `lib/bier/config.ex`)
+
+- New schema field `admin_server_port`: `{:or, [:pos_integer, nil]}`,
+  default `env(:admin_server_port, nil)`. `nil` ⇒ no admin server (opt-in,
+  matches PostgREST).
+- Add `admin_server_port` to the `Bier.Config` struct and typespec.
+- Cross-field validation in `Bier.Config.new!/2`, **after**
+  `NimbleOptions.validate!`: when `admin_server_port` is set and equals
+  `router[:port]`, raise with a message containing
+  `admin-server-port cannot be the same as server-port`.
+
+### 2. Supervision (`lib/bier.ex` `init/1`)
+
+When `admin_server_port` is set, the `Bier` supervisor starts a **second Bandit
+listener** as a child (alongside the existing pool, DynamicSupervisor, and
+`HttpServerStarter`), bound to the admin port and serving
+`Bier.Plugs.AdminRouter` — **not** the catch-all API router. The instance name
+is threaded into the plug (via `init_opts`/assign) so it can resolve the pool and
+schema cache from `Bier.Registry` / `:persistent_term`.
+
+When `admin_server_port` is `nil`, no admin child is added.
+
+### 3. `Bier.Plugs.AdminRouter` (new, `lib/bier/plugs/admin_router.ex`)
+
+A minimal `Plug.Router` with exactly two routes; everything else → `404`.
+
+- **`GET /live`** → `200` whenever the process is up. No DB access (pure
+  liveness). Small body (e.g. empty or a tiny JSON ok marker via
+  `Bier.json_library/0`).
+- **`GET /ready`** → `200` only when **both** hold, else `503`:
+  1. a lightweight `SELECT 1` over the per-instance Postgrex pool succeeds, **and**
+  2. the schema cache `:persistent_term.get({Bier, :relations, name})` is
+     populated (non-empty / present).
+
+## Data flow
+
+```
+host app → {Bier, name: X, router: [port: 4040], admin_server_port: 4041}
+  Bier.start_link → Config.new! (validates admin_server_port ≠ router port)
+  Bier supervisor children:
+    - Postgrex pool (registry: {X, Postgrex})
+    - DynamicSupervisor
+    - HttpServerStarter (builds API router, starts main Bandit on 4040)
+    - Bandit(admin) on 4041 → Bier.Plugs.AdminRouter (name: X)   ← new, only if port set
+
+GET :4041/live  → 200
+GET :4041/ready → SELECT 1 on {X, Postgrex} AND persistent_term {Bier,:relations,X}
+                  → 200 if both ok, else 503
+```
+
+## Error handling
+
+- Config: equal admin/server port → raise at boot (fail fast), message matches
+  case `1717` wording.
+- `/ready`: any failure of the DB ping (raise/timeout) or an absent/empty schema
+  cache → `503`. The check must not crash the router; failures are caught and
+  mapped to `503`.
+
+## Testing (TDD)
+
+1. **Config unit test** (`test/bier/config_test.exs` or `test/bier_test.exs`):
+   `Config.new!/2` raises when `admin_server_port == router[:port]`; accepts when
+   they differ, and when `admin_server_port` is `nil`.
+2. **Admin server integration test**: boot a `Bier` instance with an
+   `admin_server_port` against the test DB; `GET /live` → `200`; `GET /ready` →
+   `200` (DB up + cache populated).
+3. **`/ready` unhealthy path**: `503` when the schema cache is absent for the
+   instance (relations not populated in `:persistent_term`).
+
+The conformance YAML suite is left untouched (case `1717` stays `:pending` — it
+is a `--dump-config` CLI case and the harness has no CLI runner). Update the
+`admin_server` note in `spec/COVERAGE.md` to record that `/live` `/ready` now
+have integration coverage; the page stays **Partial** pending CLI + `/metrics`.
+
+## Out of scope
+
+- Prometheus `/metrics` endpoint (separate issue, built on `:telemetry`).
+- CLI `--dump-config` runner for case `1717`.
+- TLS for the admin listener.

--- a/lib/bier.ex
+++ b/lib/bier.ex
@@ -324,6 +324,9 @@ defmodule Bier do
   # admin health endpoints (separate from the catch-all API router). Started
   # statically here — it needs no introspection result; `/ready` reports 503
   # until the schema cache is populated, which is the correct readiness signal.
+  # (Boot ordering after HttpServerStarter means the cache is populated before
+  # this listener binds on the initial boot; across an HttpServerStarter restart
+  # the admin listener keeps serving the last persistent_term cache.)
   defp admin_children(%Bier.Config{admin_server_port: nil}), do: []
 
   defp admin_children(%Bier.Config{name: name, admin_server_port: port} = conf) do

--- a/lib/bier.ex
+++ b/lib/bier.ex
@@ -15,6 +15,14 @@ defmodule Bier do
         {Bier, name: MyApp.Bier, router: [port: 4040, scheme: :http]}
       ]
 
+  Pass `admin_server_port:` to also expose the `/live` and `/ready` health
+  endpoints on a separate listener (it must differ from `router[:port]`):
+
+      children = [
+        {Bier,
+         name: MyApp.Bier, router: [port: 4040, scheme: :http], admin_server_port: 4041}
+      ]
+
   See `start_link/1` for the full list of options.
 
   Per-instance processes are registered through `Bier.Registry`.

--- a/lib/bier.ex
+++ b/lib/bier.ex
@@ -259,6 +259,15 @@ defmodule Bier do
         (PostgREST db-root-spec). When set, the root endpoint serves its result
         instead of the generated spec.
         """
+      ],
+      admin_server_port: [
+        type: {:or, [:pos_integer, nil]},
+        default: env(:admin_server_port, nil),
+        doc: """
+        TCP port for the per-instance admin server exposing the `/live` and
+        `/ready` health endpoints (PostgREST admin-server-port). When `nil`
+        (the default) no admin server starts. Must differ from `router[:port]`.
+        """
       ]
     ]
   end

--- a/lib/bier.ex
+++ b/lib/bier.ex
@@ -300,23 +300,43 @@ defmodule Bier do
 
   @impl Supervisor
   def init(%Bier.Config{name: name} = conf) do
-    children = [
-      # Per-instance Postgrex pool, registered via the Bier registry so that the
-      # introspection step and the request pipeline can resolve it from the
-      # instance name. Started before HttpServerStarter, which needs it for the
-      # boot-time DB introspection.
-      Supervisor.child_spec({Postgrex, postgrex_opts(conf)}, id: {name, Postgrex}),
-      # The DynamicSupervisor must start BEFORE HttpServerStarter: the latter's
-      # `handle_continue(:start_webserver, …)` starts Bandit *as a child of this
-      # DynamicSupervisor*, so it has to already be alive — otherwise that
-      # `start_child` call races the DynamicSupervisor's own startup and crashes
-      # (the supervisor then restarts HttpServerStarter, rebuilding the router).
-      {DynamicSupervisor,
-       strategy: :one_for_one, name: Registry.via(conf.name, DynamicSupervisor)},
-      {Bier.HttpServerStarter, conf}
-    ]
+    children =
+      [
+        # Per-instance Postgrex pool, registered via the Bier registry so that the
+        # introspection step and the request pipeline can resolve it from the
+        # instance name. Started before HttpServerStarter, which needs it for the
+        # boot-time DB introspection.
+        Supervisor.child_spec({Postgrex, postgrex_opts(conf)}, id: {name, Postgrex}),
+        # The DynamicSupervisor must start BEFORE HttpServerStarter: the latter's
+        # `handle_continue(:start_webserver, …)` starts Bandit *as a child of this
+        # DynamicSupervisor*, so it has to already be alive — otherwise that
+        # `start_child` call races the DynamicSupervisor's own startup and crashes
+        # (the supervisor then restarts HttpServerStarter, rebuilding the router).
+        {DynamicSupervisor,
+         strategy: :one_for_one, name: Registry.via(conf.name, DynamicSupervisor)},
+        {Bier.HttpServerStarter, conf}
+      ] ++ admin_children(conf)
 
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  # When `admin_server_port` is set, run a second Bandit listener serving the
+  # admin health endpoints (separate from the catch-all API router). Started
+  # statically here — it needs no introspection result; `/ready` reports 503
+  # until the schema cache is populated, which is the correct readiness signal.
+  defp admin_children(%Bier.Config{admin_server_port: nil}), do: []
+
+  defp admin_children(%Bier.Config{name: name, admin_server_port: port} = conf) do
+    [
+      Supervisor.child_spec(
+        {Bandit,
+         scheme: conf.router[:scheme],
+         plug: {Bier.Plugs.AdminRouter, name: name},
+         port: port,
+         http_options: [compress: false]},
+        id: {name, :admin_server}
+      )
+    ]
   end
 
   @doc false

--- a/lib/bier/config.ex
+++ b/lib/bier/config.ex
@@ -45,7 +45,8 @@ defmodule Bier.Config do
           server_trace_header: String.t() | nil,
           log_level: :crit | :error | :warn | :info | :debug,
           openapi_mode: String.t(),
-          db_root_spec: String.t() | nil
+          db_root_spec: String.t() | nil,
+          admin_server_port: pos_integer() | nil
         }
 
   defstruct [
@@ -65,6 +66,7 @@ defmodule Bier.Config do
     :db_profile_schemas,
     :server_trace_header,
     :db_root_spec,
+    :admin_server_port,
     name: Bier,
     openapi_mode: "follow-privileges",
     pool_size: 10,
@@ -89,6 +91,21 @@ defmodule Bier.Config do
   def new!(opts, schema) do
     conf = NimbleOptions.validate!(opts, schema)
 
+    validate_admin_server_port!(conf)
+
     struct!(__MODULE__, conf)
+  end
+
+  # PostgREST rejects an admin-server-port equal to server-port at startup
+  # (test_cli.py:test_server_port_and_admin_port_same_value; conformance case
+  # 1717). NimbleOptions validates fields independently, so this cross-field
+  # check lives here.
+  defp validate_admin_server_port!(conf) do
+    admin_port = conf[:admin_server_port]
+    server_port = get_in(conf, [:router, :port])
+
+    if not is_nil(admin_port) and admin_port == server_port do
+      raise ArgumentError, "admin-server-port cannot be the same as server-port"
+    end
   end
 end

--- a/lib/bier/health.ex
+++ b/lib/bier/health.ex
@@ -1,0 +1,37 @@
+defmodule Bier.Health do
+  @moduledoc """
+  Health checks backing the per-instance admin endpoints.
+
+  `ready?/1` reports whether a named `Bier` instance can serve requests: its
+  schema cache must be populated AND its Postgrex pool must answer a trivial
+  query. The schema-cache check runs first and short-circuits, so a name with no
+  cache returns `false` without touching (a possibly absent) connection pool.
+  """
+
+  alias Bier.Registry
+
+  @doc """
+  Returns `true` when the instance `name` is ready to serve requests:
+  the schema cache is populated and the database answers `SELECT 1`.
+  """
+  @spec ready?(Bier.name()) :: boolean()
+  def ready?(name) do
+    schema_cache_populated?(name) and database_responsive?(name)
+  end
+
+  defp schema_cache_populated?(name) do
+    map_size(:persistent_term.get({Bier, :relations, name}, %{})) > 0
+  end
+
+  defp database_responsive?(name) do
+    case Postgrex.query(Registry.via(name, Postgrex), "SELECT 1", []) do
+      {:ok, _result} -> true
+      {:error, _reason} -> false
+    end
+  rescue
+    DBConnection.ConnectionError -> false
+    Postgrex.Error -> false
+  catch
+    :exit, _ -> false
+  end
+end

--- a/lib/bier/plugs/admin_router.ex
+++ b/lib/bier/plugs/admin_router.ex
@@ -1,0 +1,36 @@
+defmodule Bier.Plugs.AdminRouter do
+  @moduledoc """
+  Minimal plug for a `Bier` instance's admin server (PostgREST admin server).
+
+  Served on its own Bandit listener bound to `admin_server_port`, kept separate
+  from the catch-all API router so the health paths never collide with table
+  names. Exposes:
+
+    * `GET /live`  — `200` whenever the process is up (pure liveness).
+    * `GET /ready` — `200` when `Bier.Health.ready?/1` holds, else `503`.
+
+  Every other request returns `404`. The instance name is supplied via
+  `init/1` (`name:`) so readiness resolves the right pool and schema cache.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl Plug
+  def init(opts), do: Keyword.fetch!(opts, :name)
+
+  @impl Plug
+  def call(%Plug.Conn{method: "GET", path_info: ["live"]} = conn, _name) do
+    send_resp(conn, 200, "")
+  end
+
+  def call(%Plug.Conn{method: "GET", path_info: ["ready"]} = conn, name) do
+    status = if Bier.Health.ready?(name), do: 200, else: 503
+    send_resp(conn, status, "")
+  end
+
+  def call(conn, _name) do
+    send_resp(conn, 404, "")
+  end
+end

--- a/spec/COVERAGE.md
+++ b/spec/COVERAGE.md
@@ -42,7 +42,7 @@ Pinned target: **PostgREST v14.12**. Total cases: **532** across 17 areas.
 | `errors` (Errors) | 1500–1516 (errors), 1432–1434 (rpc errors), 1024, 1185 (not-found), 1455–1464 (auth JWT errors) | SQLSTATE→HTTP mapping, PGRST error codes, RAISE PGRST full control, 4xx/5xx envelopes. |
 | `configuration` (Configuration) | 1700–1730 (config) | Sources (env/file/db-role-settings), aliases, validation, coercion, precedence, app-settings. |
 | `observability` (Observability) | 1750–1767 (observability) | Server-Timing, trace header, log-level→status logging. |
-| `admin_server` (Admin Server) | 1717 (admin-port = server-port fatal) | Only the port-collision validation. Partial — no `/live` `/ready` health-endpoint case. |
+| `admin_server` (Admin Server) | 1717 (admin-port = server-port fatal) | Port-collision validation (case 1717, library-enforced in `Bier.Config`) plus `/live`/`/ready` covered by ExUnit (`test/bier/admin_server_test.exs`). Partial — case 1717 stays `:pending` (CLI `--dump-config`), `/metrics` not yet implemented. |
 | `listener` (Listener) | — (DEFERRED) | LISTEN/NOTIFY channel (`db-channel`) reload trigger needs the same reload-signal harness. See **Scope decisions**. |
 
 ## Scope decisions

--- a/test/bier/admin_server_test.exs
+++ b/test/bier/admin_server_test.exs
@@ -6,11 +6,13 @@ defmodule Bier.AdminServerTest do
   """
   use ExUnit.Case, async: false
 
+  alias Bier.TestPorts
+
   @moduletag :integration
 
   setup do
-    api_port = free_port()
-    admin_port = free_port()
+    api_port = TestPorts.free_port()
+    admin_port = TestPorts.free_port()
 
     opts =
       [
@@ -20,7 +22,7 @@ defmodule Bier.AdminServerTest do
       ] ++ Bier.ConformanceServer.base_opts()
 
     start_supervised!({Bier, opts})
-    wait_until_listening(admin_port)
+    TestPorts.wait_until_listening(admin_port)
 
     %{admin_port: admin_port}
   end
@@ -38,27 +40,5 @@ defmodule Bier.AdminServerTest do
   test "unknown admin paths return 404", %{admin_port: admin_port} do
     resp = Req.get!("http://127.0.0.1:#{admin_port}/nope", retry: false)
     assert resp.status == 404
-  end
-
-  defp free_port do
-    {:ok, sock} = :gen_tcp.listen(0, [:binary, ip: {127, 0, 0, 1}])
-    {:ok, port} = :inet.port(sock)
-    :gen_tcp.close(sock)
-    port
-  end
-
-  defp wait_until_listening(port, retries \\ 100) do
-    case :gen_tcp.connect(~c"127.0.0.1", port, [], 10) do
-      {:ok, sock} ->
-        :gen_tcp.close(sock)
-        :ok
-
-      {:error, _} when retries > 0 ->
-        Process.sleep(20)
-        wait_until_listening(port, retries - 1)
-
-      {:error, reason} ->
-        raise "admin server did not come up on port #{port}: #{inspect(reason)}"
-    end
   end
 end

--- a/test/bier/admin_server_test.exs
+++ b/test/bier/admin_server_test.exs
@@ -1,0 +1,64 @@
+defmodule Bier.AdminServerTest do
+  @moduledoc """
+  Boots a dedicated Bier instance with an admin server against the test DB and
+  exercises the health endpoints over HTTP. Not async: it binds real ports and
+  runs DB introspection at boot.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :integration
+
+  setup do
+    api_port = free_port()
+    admin_port = free_port()
+
+    opts =
+      [
+        name: :"admin_it_#{System.unique_integer([:positive])}",
+        router: [port: api_port, scheme: :http],
+        admin_server_port: admin_port
+      ] ++ Bier.ConformanceServer.base_opts()
+
+    start_supervised!({Bier, opts})
+    wait_until_listening(admin_port)
+
+    %{admin_port: admin_port}
+  end
+
+  test "GET /live returns 200", %{admin_port: admin_port} do
+    resp = Req.get!("http://127.0.0.1:#{admin_port}/live", retry: false)
+    assert resp.status == 200
+  end
+
+  test "GET /ready returns 200 once the schema cache is populated", %{admin_port: admin_port} do
+    resp = Req.get!("http://127.0.0.1:#{admin_port}/ready", retry: false)
+    assert resp.status == 200
+  end
+
+  test "unknown admin paths return 404", %{admin_port: admin_port} do
+    resp = Req.get!("http://127.0.0.1:#{admin_port}/nope", retry: false)
+    assert resp.status == 404
+  end
+
+  defp free_port do
+    {:ok, sock} = :gen_tcp.listen(0, [:binary, ip: {127, 0, 0, 1}])
+    {:ok, port} = :inet.port(sock)
+    :gen_tcp.close(sock)
+    port
+  end
+
+  defp wait_until_listening(port, retries \\ 100) do
+    case :gen_tcp.connect(~c"127.0.0.1", port, [], 10) do
+      {:ok, sock} ->
+        :gen_tcp.close(sock)
+        :ok
+
+      {:error, _} when retries > 0 ->
+        Process.sleep(20)
+        wait_until_listening(port, retries - 1)
+
+      {:error, reason} ->
+        raise "admin server did not come up on port #{port}: #{inspect(reason)}"
+    end
+  end
+end

--- a/test/bier/health_test.exs
+++ b/test/bier/health_test.exs
@@ -1,0 +1,20 @@
+defmodule Bier.HealthTest do
+  use ExUnit.Case, async: true
+
+  describe "ready?/1" do
+    test "is false when the schema cache is absent (no DB ping needed)" do
+      # An instance name that was never booted has no :persistent_term relations
+      # entry and no Postgrex pool. ready?/1 must short-circuit to false on the
+      # empty cache without raising on the missing pool.
+      name = :"never_booted_#{System.unique_integer([:positive])}"
+      refute Bier.Health.ready?(name)
+    end
+
+    test "is false when the schema cache is present but empty" do
+      name = :"empty_cache_#{System.unique_integer([:positive])}"
+      :persistent_term.put({Bier, :relations, name}, %{})
+      on_exit(fn -> :persistent_term.erase({Bier, :relations, name}) end)
+      refute Bier.Health.ready?(name)
+    end
+  end
+end

--- a/test/bier/plugs/admin_router_test.exs
+++ b/test/bier/plugs/admin_router_test.exs
@@ -1,0 +1,30 @@
+defmodule Bier.Plugs.AdminRouterTest do
+  use ExUnit.Case, async: true
+  import Plug.Test
+
+  alias Bier.Plugs.AdminRouter
+
+  defp call(method, path, name) do
+    conn(method, path)
+    |> AdminRouter.call(AdminRouter.init(name: name))
+  end
+
+  test "GET /live returns 200 regardless of readiness" do
+    name = :"live_#{System.unique_integer([:positive])}"
+    conn = call(:get, "/live", name)
+    assert conn.status == 200
+  end
+
+  test "GET /ready returns 503 when the instance is not ready" do
+    # No schema cache for this name -> Bier.Health.ready?/1 is false.
+    name = :"notready_#{System.unique_integer([:positive])}"
+    conn = call(:get, "/ready", name)
+    assert conn.status == 503
+  end
+
+  test "unknown paths return 404" do
+    name = :"unknown_#{System.unique_integer([:positive])}"
+    assert call(:get, "/metrics", name).status == 404
+    assert call(:post, "/live", name).status == 404
+  end
+end

--- a/test/bier_test.exs
+++ b/test/bier_test.exs
@@ -1,3 +1,31 @@
 defmodule BierTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
+  describe "Bier.Config.new!/2 admin-server-port validation" do
+    defp opts(extra), do: [name: :"admin_cfg_#{System.unique_integer([:positive])}"] ++ extra
+
+    test "rejects admin_server_port equal to the router port" do
+      assert_raise ArgumentError, ~r/admin-server-port cannot be the same as server-port/, fn ->
+        Bier.Config.new!(
+          opts(router: [port: 3000, scheme: :http], admin_server_port: 3000),
+          Bier.schema()
+        )
+      end
+    end
+
+    test "accepts admin_server_port that differs from the router port" do
+      conf =
+        Bier.Config.new!(
+          opts(router: [port: 3000, scheme: :http], admin_server_port: 3001),
+          Bier.schema()
+        )
+
+      assert conf.admin_server_port == 3001
+    end
+
+    test "accepts a nil admin_server_port (default, admin server disabled)" do
+      conf = Bier.Config.new!(opts(router: [port: 3000, scheme: :http]), Bier.schema())
+      assert conf.admin_server_port == nil
+    end
+  end
 end

--- a/test/support/conformance_server.ex
+++ b/test/support/conformance_server.ex
@@ -52,9 +52,9 @@ defmodule Bier.ConformanceServer do
   end
 
   defp start_instance(name, opts) do
-    port = free_port()
+    port = Bier.TestPorts.free_port()
     {:ok, _pid} = Bier.start_link([name: name, router: [port: port, scheme: :http]] ++ opts)
-    wait_until_listening(port)
+    Bier.TestPorts.wait_until_listening(port)
     "http://127.0.0.1:#{port}"
   end
 
@@ -134,30 +134,5 @@ defmodule Bier.ConformanceServer do
       server_trace_header: "X-Request-Id",
       log_level: :error
     ]
-  end
-
-  defp free_port do
-    {:ok, sock} = :gen_tcp.listen(0, [:binary, ip: {127, 0, 0, 1}])
-    {:ok, port} = :inet.port(sock)
-    # TOCTOU: tiny window between closing this probe socket and Bandit binding.
-    # Acceptable for a single suite run; avoid parallel suite runs on one host.
-    :gen_tcp.close(sock)
-    port
-  end
-
-  defp wait_until_listening(port, retries \\ 100) do
-    # Each attempt: up to ~10ms connect + 20ms sleep ≈ 30ms; 100 retries ≈ 3s ceiling.
-    case :gen_tcp.connect(~c"127.0.0.1", port, [], 10) do
-      {:ok, sock} ->
-        :gen_tcp.close(sock)
-        :ok
-
-      {:error, _} when retries > 0 ->
-        Process.sleep(20)
-        wait_until_listening(port, retries - 1)
-
-      {:error, reason} ->
-        raise "Bier conformance server did not come up on port #{port}: #{inspect(reason)}"
-    end
   end
 end

--- a/test/support/test_ports.ex
+++ b/test/support/test_ports.ex
@@ -1,0 +1,39 @@
+defmodule Bier.TestPorts do
+  @moduledoc """
+  Port helpers shared by tests that boot real Bandit listeners.
+  """
+
+  @doc """
+  Returns a currently-free TCP port on the loopback interface.
+
+  TOCTOU: there is a tiny window between closing this probe socket and the
+  caller binding the port. Acceptable for a single suite run; avoid parallel
+  suite runs on one host.
+  """
+  def free_port do
+    {:ok, sock} = :gen_tcp.listen(0, [:binary, ip: {127, 0, 0, 1}])
+    {:ok, port} = :inet.port(sock)
+    :gen_tcp.close(sock)
+    port
+  end
+
+  @doc """
+  Blocks until something is listening on `port`, or raises after exhausting
+  `retries`. Each attempt: up to ~10ms connect + 20ms sleep ≈ 30ms; 100 retries
+  ≈ 3s ceiling.
+  """
+  def wait_until_listening(port, retries \\ 100) do
+    case :gen_tcp.connect(~c"127.0.0.1", port, [], 10) do
+      {:ok, sock} ->
+        :gen_tcp.close(sock)
+        :ok
+
+      {:error, _} when retries > 0 ->
+        Process.sleep(20)
+        wait_until_listening(port, retries - 1)
+
+      {:error, reason} ->
+        raise "port #{port} did not come up: #{inspect(reason)}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds opt-in, per-instance admin health endpoints, closing #30.

- New `admin_server_port` config (default `nil` = disabled). When set, each `Bier` instance starts a **second Bandit listener** on that port serving a dedicated `Bier.Plugs.AdminRouter` — separate from the catch-all API router, so the health paths never collide with table names and the admin surface can be firewalled independently.
- `GET /live` → `200` (pure liveness, no DB).
- `GET /ready` → `200` when the instance's schema cache is populated **and** a `SELECT 1` over its Postgrex pool succeeds; `503` otherwise. Readiness is computed per-instance (per-DB), via `Bier.Health.ready?/1`.
- Validates `admin_server_port` ≠ `router[:port]` in `Bier.Config.new!/2`, raising with the case-1717 wording (`admin-server-port cannot be the same as server-port`).

### Why a separate port (vs PostgREST's single-DB model)
Bier serves multiple DBs at once (one DB per supervisor instance), so health is inherently per-instance. The API router is a catch-all that resolves `GET /<path>` to a `{schema, relation}` lookup, so `/live`/`/ready` on the main port would collide with table names. A separate per-instance admin port preserves PostgREST-compatible root URLs and keeps the admin surface isolated. See `docs/superpowers/specs/2026-06-07-admin-health-endpoints-design.md`.

### Out of scope
Prometheus `/metrics` (separate issue), CLI `--dump-config` runner (case 1717 stays `:pending`), admin TLS.

## Test Plan
- [x] `Bier.Config.new!/2` validation: rejects equal admin/server ports, accepts differing/nil (`test/bier_test.exs`)
- [x] `Bier.Health.ready?/1`: false on absent/empty schema cache, short-circuits before DB (`test/bier/health_test.exs`)
- [x] `Bier.Plugs.AdminRouter`: `/live` 200, `/ready` 503 when not ready, 404 fallthrough (`test/bier/plugs/admin_router_test.exs`)
- [x] Integration: boots an instance with an admin port against the test DB, `GET /live`/`/ready` → 200, unknown → 404 (`test/bier/admin_server_test.exs`)
- [x] CI gates: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix docs --warnings-as-errors`, `mix deps.unlock --check-unused`
- [x] 11 feature tests, 0 failures; remaining full-suite failures are pre-existing conformance baseline cases (geojson, RS256 JWT), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)