### PR TITLE
feat: evaluate body_jsonpath conformance assertions (closes #38)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-jsonpath-conformance-assertions.md
+++ b/docs/superpowers/plans/2026-06-07-jsonpath-conformance-assertions.md
@@ -1,0 +1,516 @@
+# JSONPath body assertions (#38) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the conformance harness evaluate `expect.body_jsonpath` so the non-openapi cases that use it run instead of being excluded.
+
+**Architecture:** A tiny, dependency-free JSONPath-subset resolver (`Bier.ConformanceJsonPath`) navigates the decoded response body; a new `body_jsonpath` clause in `Bier.ConformanceAssertions` layers the `equals`/`present`/`absent`/`exists` matcher on top. The conformance generator stops tagging non-openapi `body_jsonpath` cases `:pending`; openapi cases stay excluded under a new `:openapi_doc` reason (they need the generated document, #39) so CI stays green.
+
+**Tech Stack:** Elixir, ExUnit, `yaml_elixir` (case loading), `Bier.json_library/0` (JSON decode). No new dependency.
+
+See the design: `docs/superpowers/specs/2026-06-07-jsonpath-conformance-assertions-design.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `test/support/conformance_json_path.ex` (create) | `Bier.ConformanceJsonPath`: `parse/1`, `resolve/2`, `fetch/2`. Pure, no deps. |
+| `test/bier/conformance_json_path_test.exs` (create) | Unit tests for parse/resolve/fetch. |
+| `test/support/conformance_assertions.ex` (modify) | Add the `body_jsonpath` check clause. |
+| `test/bier/conformance_assertions_test.exs` (modify) | Matcher tests for `body_jsonpath`. |
+| `test/conformance/conformance_test.exs` (modify) | Swap the broad `:jsonpath` pending arm for a narrow `:openapi_doc` arm. |
+
+All changes are test-only. No `lib/` or `mix.exs` changes.
+
+---
+
+## Task 1: `Bier.ConformanceJsonPath.parse/1`
+
+**Files:**
+- Create: `test/support/conformance_json_path.ex`
+- Test: `test/bier/conformance_json_path_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/bier/conformance_json_path_test.exs`:
+
+```elixir
+defmodule Bier.ConformanceJsonPathTest do
+  use ExUnit.Case, async: true
+
+  alias Bier.ConformanceJsonPath, as: JP
+
+  describe "parse/1" do
+    test "root only" do
+      assert JP.parse("$") == []
+    end
+
+    test "dot members" do
+      assert JP.parse("$.code") == [{:key, "code"}]
+      assert JP.parse("$.info.title") == [{:key, "info"}, {:key, "title"}]
+      assert JP.parse("$.a_json") == [{:key, "a_json"}]
+    end
+
+    test "bracket string keys (slash, dollar, digits)" do
+      assert JP.parse("$.paths['/child_entities']") ==
+               [{:key, "paths"}, {:key, "/child_entities"}]
+
+      assert JP.parse("$.x['$ref']") == [{:key, "x"}, {:key, "$ref"}]
+      assert JP.parse("$.responses['200']") == [{:key, "responses"}, {:key, "200"}]
+    end
+
+    test "array indices" do
+      assert JP.parse("$[0].Plan") == [{:index, 0}, {:key, "Plan"}]
+      assert JP.parse("$.tags[0]") == [{:key, "tags"}, {:index, 0}]
+    end
+
+    test "mixed chain" do
+      assert JP.parse("$.paths['/child_entities'].get.responses['200'].description") ==
+               [
+                 {:key, "paths"},
+                 {:key, "/child_entities"},
+                 {:key, "get"},
+                 {:key, "responses"},
+                 {:key, "200"},
+                 {:key, "description"}
+               ]
+    end
+
+    test "malformed paths raise ArgumentError" do
+      assert_raise ArgumentError, fn -> JP.parse("code") end
+      assert_raise ArgumentError, fn -> JP.parse("$.") end
+      assert_raise ArgumentError, fn -> JP.parse("$['unterminated") end
+      assert_raise ArgumentError, fn -> JP.parse("$[]") end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/conformance_json_path_test.exs`
+Expected: FAIL — `Bier.ConformanceJsonPath.parse/1 is undefined (module ... is not available)`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `test/support/conformance_json_path.ex`:
+
+```elixir
+defmodule Bier.ConformanceJsonPath do
+  @moduledoc """
+  A deterministic, single-match JSONPath subset for the conformance harness's
+  `expect.body_jsonpath` assertions.
+
+  Supports exactly the grammar the conformance cases use — root `$`, dot member
+  `.key`, bracket string key `['key']` (keys may contain `/`, `$`, digits), and
+  array index `[n]`. It deliberately does NOT support filters (`?()`), recursive
+  descent (`..`), wildcards (`[*]`/`.*`), or slices; such syntax raises rather
+  than being silently ignored. Inputs are trusted (our own checked-in spec
+  files), so the parser fails fast on a malformed path to surface authoring
+  typos at the assertion site.
+  """
+
+  @type segment :: {:key, String.t()} | {:index, non_neg_integer()}
+
+  @doc """
+  Parse a path string into a list of segments. Raises `ArgumentError` on a
+  malformed path. `"$"` parses to `[]` (the whole document).
+  """
+  @spec parse(String.t()) :: [segment()]
+  def parse("$" <> rest), do: parse_segments(rest, [], "$" <> rest)
+  def parse(path), do: raise(ArgumentError, "JSONPath must start with $: #{inspect(path)}")
+
+  defp parse_segments("", acc, _orig), do: Enum.reverse(acc)
+
+  # .identifier
+  defp parse_segments("." <> rest, acc, orig) do
+    {ident, rest} = take_ident(rest, "")
+    if ident == "", do: bad(orig)
+    parse_segments(rest, [{:key, ident} | acc], orig)
+  end
+
+  # ['quoted string']  (must be tried before the bare-"[" clause below)
+  defp parse_segments("['" <> rest, acc, orig) do
+    case take_until_quote(rest, "") do
+      {key, "]" <> rest2} -> parse_segments(rest2, [{:key, key} | acc], orig)
+      _ -> bad(orig)
+    end
+  end
+
+  # [integer]
+  defp parse_segments("[" <> rest, acc, orig) do
+    case take_digits(rest, "") do
+      {"", _} -> bad(orig)
+      {digits, "]" <> rest2} -> parse_segments(rest2, [{:index, String.to_integer(digits)} | acc], orig)
+      _ -> bad(orig)
+    end
+  end
+
+  defp parse_segments(_other, _acc, orig), do: bad(orig)
+
+  defp take_ident(<<c, rest::binary>>, acc)
+       when c in ?a..?z or c in ?A..?Z or c in ?0..?9 or c == ?_,
+       do: take_ident(rest, acc <> <<c>>)
+
+  defp take_ident(rest, acc), do: {acc, rest}
+
+  defp take_digits(<<c, rest::binary>>, acc) when c in ?0..?9,
+    do: take_digits(rest, acc <> <<c>>)
+
+  defp take_digits(rest, acc), do: {acc, rest}
+
+  # Read until the closing single quote. No escaping is needed for the corpus;
+  # an unterminated quote returns :unterminated, which the caller turns into a
+  # parse error.
+  defp take_until_quote("'" <> rest, acc), do: {acc, rest}
+  defp take_until_quote(<<c, rest::binary>>, acc), do: take_until_quote(rest, acc <> <<c>>)
+  defp take_until_quote("", _acc), do: :unterminated
+
+  defp bad(orig), do: raise(ArgumentError, "malformed JSONPath: #{inspect(orig)}")
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/conformance_json_path_test.exs`
+Expected: PASS (the `parse/1` describe block; `resolve`/`fetch` not tested yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/support/conformance_json_path.ex test/bier/conformance_json_path_test.exs
+git commit -m "feat(#38): JSONPath subset parser for the conformance harness"
+```
+
+---
+
+## Task 2: `resolve/2` and `fetch/2`
+
+**Files:**
+- Modify: `test/support/conformance_json_path.ex`
+- Test: `test/bier/conformance_json_path_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append these describe blocks inside `Bier.ConformanceJsonPathTest` (before the final `end`):
+
+```elixir
+  describe "resolve/2" do
+    @doc_term %{
+      "swagger" => "2.0",
+      "info" => %{"title" => "API"},
+      "details" => nil,
+      "paths" => %{"/x" => %{"get" => %{"tags" => ["a", "b"]}}},
+      "list" => [%{"Plan" => 1}]
+    }
+
+    test "whole document for empty segments" do
+      assert JP.resolve([], @doc_term) == {:ok, @doc_term}
+    end
+
+    test "nested key hit" do
+      assert JP.resolve([{:key, "info"}, {:key, "title"}], @doc_term) == {:ok, "API"}
+    end
+
+    test "key present with null value is a hit (not missing)" do
+      assert JP.resolve([{:key, "details"}], @doc_term) == {:ok, nil}
+    end
+
+    test "bracket-keyed path and array index" do
+      assert JP.resolve(
+               [{:key, "paths"}, {:key, "/x"}, {:key, "get"}, {:key, "tags"}, {:index, 1}],
+               @doc_term
+             ) == {:ok, "b"}
+
+      assert JP.resolve([{:index, 0}, {:key, "Plan"}], @doc_term["list"]) == {:ok, 1}
+    end
+
+    test "missing key, out-of-range index, and type mismatch are :missing" do
+      assert JP.resolve([{:key, "nope"}], @doc_term) == :missing
+      assert JP.resolve([{:key, "list"}, {:index, 9}], @doc_term) == :missing
+      assert JP.resolve([{:key, "swagger"}, {:key, "x"}], @doc_term) == :missing
+    end
+  end
+
+  describe "fetch/2" do
+    test "parses then resolves" do
+      term = %{"a" => %{"b" => [10, 20]}}
+      assert JP.fetch(term, "$.a.b[1]") == {:ok, 20}
+      assert JP.fetch(term, "$.a.c") == :missing
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/conformance_json_path_test.exs`
+Expected: FAIL — `Bier.ConformanceJsonPath.resolve/2 is undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `Bier.ConformanceJsonPath` (before the final `end` of the module):
+
+```elixir
+  @doc "Resolve parsed `segments` against a decoded JSON term."
+  @spec resolve([segment()], term()) :: {:ok, term()} | :missing
+  def resolve([], term), do: {:ok, term}
+
+  def resolve([{:key, k} | rest], term) when is_map(term) do
+    case Map.fetch(term, k) do
+      {:ok, value} -> resolve(rest, value)
+      :error -> :missing
+    end
+  end
+
+  def resolve([{:index, i} | rest], term) when is_list(term) and i < length(term),
+    do: resolve(rest, Enum.at(term, i))
+
+  def resolve(_segments, _term), do: :missing
+
+  @doc "Parse `path` and resolve it against `term`."
+  @spec fetch(term(), String.t()) :: {:ok, term()} | :missing
+  def fetch(term, path), do: path |> parse() |> resolve(term)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/conformance_json_path_test.exs`
+Expected: PASS (all parse/resolve/fetch tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/support/conformance_json_path.ex test/bier/conformance_json_path_test.exs
+git commit -m "feat(#38): resolve/fetch for the JSONPath subset"
+```
+
+---
+
+## Task 3: `body_jsonpath` matcher in `ConformanceAssertions`
+
+**Files:**
+- Modify: `test/support/conformance_assertions.ex`
+- Test: `test/bier/conformance_assertions_test.exs:101` (add tests before the final `end`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add these tests to `Bier.ConformanceAssertionsTest` (before the final `end`). They reuse the existing `resp/1` helper:
+
+```elixir
+  test "body_jsonpath equals (incl. null), present, exists, absent" do
+    body =
+      ~s({"code":"PGRST106","details":null,"swagger":"2.0",) <>
+        ~s("paths":{"/x":{"get":{"tags":["t0"]}}}})
+
+    r = resp(%{body: body})
+
+    assert_expect(r, %{
+      "body_jsonpath" => [
+        %{"path" => "$.code", "equals" => "PGRST106"},
+        %{"path" => "$.details", "equals" => nil},
+        %{"path" => "$.paths['/x'].get.tags[0]", "equals" => "t0"},
+        %{"path" => "$.swagger", "present" => true},
+        %{"path" => "$.swagger", "exists" => true},
+        %{"path" => "$.paths['/missing']", "absent" => true}
+      ]
+    })
+  end
+
+  test "body_jsonpath equals mismatch fails" do
+    r = resp(%{body: ~s({"code":"PGRST106"})})
+
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_expect(r, %{"body_jsonpath" => [%{"path" => "$.code", "equals" => "OTHER"}]})
+    end
+  end
+
+  test "body_jsonpath absent fails when the node is present" do
+    r = resp(%{body: ~s({"a":1})})
+
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_expect(r, %{"body_jsonpath" => [%{"path" => "$.a", "absent" => true}]})
+    end
+  end
+
+  test "body_jsonpath present fails when the node is missing" do
+    r = resp(%{body: ~s({"a":1})})
+
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_expect(r, %{"body_jsonpath" => [%{"path" => "$.b", "present" => true}]})
+    end
+  end
+
+  test "body_jsonpath unknown predicate raises (never silently passes)" do
+    r = resp(%{body: ~s({"a":1})})
+
+    assert_raise RuntimeError, ~r/unsupported body_jsonpath predicate/, fn ->
+      assert_expect(r, %{"body_jsonpath" => [%{"path" => "$.a", "bogus" => true}]})
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/conformance_assertions_test.exs`
+Expected: FAIL — the catch-all clause raises `unsupported assertion key: "body_jsonpath"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `test/support/conformance_assertions.ex`, add these clauses immediately **before** the catch-all `defp check(key, _val, _resp)` (line 101):
+
+```elixir
+  defp check("body_jsonpath", entries, resp) when is_list(entries) do
+    decoded = decode_json(resp.body)
+    Enum.each(entries, &check_jsonpath_entry(&1, decoded))
+  end
+```
+
+And add these private helpers (anywhere among the other `defp`s, e.g. just above `decode_json/1`):
+
+```elixir
+  defp check_jsonpath_entry(%{"path" => path} = entry, decoded) do
+    result = Bier.ConformanceJsonPath.fetch(decoded, path)
+
+    cond do
+      Map.has_key?(entry, "equals") ->
+        expected = Map.fetch!(entry, "equals")
+
+        assert result == {:ok, expected},
+               "body_jsonpath #{path} equals mismatch:\n" <>
+                 "  expected: #{inspect(expected)}\n  got:      #{inspect(result)}"
+
+      Map.get(entry, "present") == true or Map.get(entry, "exists") == true ->
+        assert match?({:ok, _}, result),
+               "body_jsonpath #{path} expected to be present, got: #{inspect(result)}"
+
+      Map.get(entry, "absent") == true ->
+        assert result == :missing,
+               "body_jsonpath #{path} expected to be absent, got: #{inspect(result)}"
+
+      true ->
+        raise "unsupported body_jsonpath predicate in entry: #{inspect(entry)}"
+    end
+  end
+
+  defp check_jsonpath_entry(entry, _decoded) do
+    raise "body_jsonpath entry missing \"path\": #{inspect(entry)}"
+  end
+```
+
+> Note: `equals` uses plain `==` on `{:ok, value}`, matching the house semantics of `body_exact`/`body_json`. `equals: null` therefore means "present and equal to null" (`{:ok, nil}`), distinct from `absent`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/conformance_assertions_test.exs`
+Expected: PASS (all existing tests plus the five new `body_jsonpath` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/support/conformance_assertions.ex test/bier/conformance_assertions_test.exs
+git commit -m "feat(#38): body_jsonpath matcher (equals/present/absent/exists)"
+```
+
+---
+
+## Task 4: Enable non-openapi cases; gate openapi under `:openapi_doc`
+
+**Files:**
+- Modify: `test/conformance/conformance_test.exs:6-23`
+
+Rationale: removing the `:jsonpath` pending arm entirely would turn the 28 openapi cases red (the OpenAPI document is still a stub until #39). Instead, enable the 11 non-openapi `body_jsonpath` cases and keep the openapi ones excluded under a new, honest reason `:openapi_doc` that points at #39 — CI stays green and nothing is dishonestly hidden.
+
+- [ ] **Step 1: Update the moduledoc and the `pending_reason` cond**
+
+In `test/conformance/conformance_test.exs`, replace the moduledoc reason sentence and the `pending_reason` cond.
+
+Change the moduledoc line that lists reasons (lines 6-9) to include the new reason:
+
+```elixir
+  Cases the current harness cannot evaluate are tagged :pending and
+  excluded (see pending_reason): :cli (no CLI), :jwt (needs JWT signing),
+  :openapi_doc (openapi body_jsonpath cases need the generated OpenAPI
+  document, #39), :status_text (req does not expose the HTTP reason phrase).
+```
+
+Replace the `pending_reason` cond (currently lines 16-23):
+
+```elixir
+    pending_reason =
+      cond do
+        c.kind == :cli ->
+          :cli
+
+        Map.has_key?(c.request, "jwt") ->
+          :jwt
+
+        # body_jsonpath now evaluates (see Bier.ConformanceJsonPath), EXCEPT the
+        # openapi-area cases, which assert the generated OpenAPI document that is
+        # still a stub until #39. Keep those excluded under an honest reason.
+        Map.has_key?(c.expect, "body_jsonpath") and c.area == "openapi" ->
+          :openapi_doc
+
+        Map.has_key?(c.expect, "status_text") ->
+          :status_text
+
+        true ->
+          nil
+      end
+```
+
+- [ ] **Step 2: Run the full conformance suite**
+
+Run: `mix test test/conformance/conformance_test.exs`
+Expected: the 11 non-openapi `body_jsonpath` cases now execute (no longer excluded). The 28 openapi cases remain excluded (now reason `:openapi_doc`). The pre-existing unrelated failures (1467 RS256, 1616–1618 geojson) still fail; that is expected.
+
+- [ ] **Step 3: Triage the newly-enabled cases**
+
+Run and inspect just the newly-enabled cases:
+
+Run: `mix test test/conformance/conformance_test.exs 2>&1 | grep -E "test (1010|1012|1016|1356|1358|1393|1501|1502|1619|1625|1703) "`
+
+Expected: most/all pass. For any that **fail**, determine the cause:
+- If the failure is a genuine unimplemented `lib/` behavior (out of scope for #38, which only adds the evaluator), do NOT fix `lib/` here. Tag that one case `:pending` with a precise reason and open/ξreference a tracking issue, so CI stays green and the gap is recorded. Add a clause to the cond, e.g.:
+
+```elixir
+        # <case id>: <behavior> not implemented yet — see issue #<n>.
+        c.id == <case_id> ->
+          :<reason>
+```
+
+- If the failure is a bug in this task's evaluator/matcher, fix the evaluator/matcher (return to Task 1–3) — never weaken a test to make it pass.
+
+Record the outcome (which of the 11 are green, which are deferred and why) in the commit message.
+
+- [ ] **Step 4: Run the whole suite and the CI gates**
+
+Run:
+```bash
+mix format --check-formatted
+mix compile --warnings-as-errors
+mix test
+```
+Expected: `mix test` finishes with only the pre-existing unrelated failures (1467, 1616–1618) — no new failures. `format` and `compile` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/conformance/conformance_test.exs
+git commit -m "test(#38): evaluate non-openapi body_jsonpath; gate openapi on #39"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §3 components → Tasks 1–2 (`ConformanceJsonPath`), Task 3 (matcher), Task 4 (generator). §4 grammar/segments → Task 1 tests + impl. §4 resolve semantics (`:missing` for miss/range/type) → Task 2 tests. §5 matcher table (equals/present/exists/absent, unknown raises) → Task 3 tests. §6 error handling (malformed raises, unknown predicate raises, non-JSON flunks) → Tasks 1 & 3. §7 test plan → Tasks 1–4. §1 "28 openapi stay red pending #39, not re-hidden" → Task 4 `:openapi_doc` gating (refined from the spec's "remove the arm" to keep CI green; same spirit — reason now points explicitly at #39).
+- **Placeholder scan:** none — every code step shows full code; Task 4 Step 3's `<case_id>`/`<n>` are intentional fill-ins only used if a real lib gap surfaces, with explicit instructions.
+- **Type consistency:** `segment` = `{:key, String.t()} | {:index, non_neg_integer()}` used uniformly; `parse/1`→`resolve/2`→`fetch/2` signatures consistent across Tasks 1–3; matcher calls `Bier.ConformanceJsonPath.fetch/2` exactly as defined.
+
+## Notes for the implementer
+
+- This worktree (`worktree-jsonpath-conformance-assertions`) is isolated from the telemetry PR (#37). Run `mix deps.get` if `deps/` is absent.
+- `test/support/**` is compiled only in `:test` (see `mix.exs` `elixirc_paths`), so the new module is available to tests but never shipped.
+- Do not add a JSONPath dependency or `nimble_parsec` (see the design's §2 rationale).

--- a/docs/superpowers/specs/2026-06-07-jsonpath-conformance-assertions-design.md
+++ b/docs/superpowers/specs/2026-06-07-jsonpath-conformance-assertions-design.md
@@ -1,0 +1,203 @@
+# JSONPath body assertions for the conformance harness (#38) — Design
+
+> Status: draft (design). Implementation plan to follow via writing-plans.
+> Scope: GitHub issue #38. Test-harness only (`test/support/**` + the generator).
+> Unblocks `expect.body_jsonpath` (39 cases currently tagged `:pending`).
+
+## 1. Goal
+
+Let the conformance suite evaluate the `expect.body_jsonpath` assertion vocabulary
+so the 39 cases that use it can run instead of being excluded. Today
+`test/conformance/conformance_test.exs` tags any case with
+`expect.body_jsonpath` as `@tag :pending` (reason `:jsonpath`) because the
+harness has no JSONPath evaluator — making `:jsonpath` the single biggest driver
+of the conformance gap (39 of 80 pending cases).
+
+This delivers the **evaluator + matcher only**. Of the 39 cases:
+
+- **11 are non-openapi** (url_grammar, mutations, errors, content_negotiation,
+  config) and should flip to green on this work alone — *provided* the underlying
+  responses are already correct (to be confirmed during implementation; a real
+  red here is a useful lib-bug signal, not a defect of this harness work).
+- **28 are openapi** (`1650–1680`). This work lets them be *asserted*, but they
+  remain red until the OpenAPI document is generated (#39). The evaluator is a
+  prerequisite for #39 paying off; the two compose.
+
+## 2. Why not a JSONPath dependency (settled during brainstorming)
+
+The need splits in two, and a library only covers the trivial half:
+
+1. **Path navigation** over the decoded body — a 4-rule, deterministic,
+   single-match subset (see §4). Confirmed across all 39 cases: **zero** filters
+   (`?()`), recursive descent (`..`), wildcards (`[*]`/`.*`), or slices.
+2. **The matcher** — `equals` (deep JSON equality vs a YAML-decoded value,
+   including nested objects), plus `present` / `absent` / `exists`. **No JSONPath
+   library provides this**; we build it regardless.
+
+The Elixir JSONPath landscape (researched 2026-06-07):
+
+| Library | Latest | Released | Notes |
+| --- | --- | --- | --- |
+| `exjsonpath` | 0.9.0 | Mar 2020 | unmaintained; pre-RFC-9535 |
+| `warpath` | 0.6.3 | Sep 2022 | unmaintained; pre-RFC-9535 |
+| `json_path` | 0.3 | Jun 2026 | RFC-9535 compliant but days-old, pre-1.0 |
+
+A dependency would save ~40 lines of trivial path-walking while adding a
+stale-or-volatile transitive dep, requiring validation of our bracket edge cases
+(`['$ref']`, `['/child_entities']`, `['200']`) that pre-RFC parsers often get
+wrong, and *still* leaving us to hand-roll the matcher. For this codebase the
+library is the higher long-term-maintenance option. **Decision: a small,
+purpose-built resolver (Option A), behind a clean `fetch/2` seam so a library
+could be swapped in later if requirements ever grow filters/wildcards.**
+
+### Note on security / input handling
+
+This code is **test-only** and every input is **trusted and local**: `path`
+strings come from our checked-in `spec/conformance/cases/*.yaml`; it navigates an
+in-memory decoded JSON term and builds **no SQL, query, or shell**. There is no
+injection surface here (the untrusted HTTP query string is a *different*
+subsystem, `Bier.QueryParser`, already defended by parameterized SQL). We still
+parse the path into a structured form up front — not for security, but so a
+malformed path **fails fast with a clear error** (catching our own YAML typos)
+instead of silently mis-navigating.
+
+`nimble_parsec` is **not** used: the grammar is four productions (a ~20-line hand
+tokenizer is clearer at this altitude), and the repo deliberately keeps
+`nimble_parsec` `only: :dev, runtime: false` (it only *generates* the
+dependency-free `QueryParser`). Test-only code stays dependency-free.
+
+## 3. Architecture
+
+```
+expect.body_jsonpath: [ { path: "...", equals|present|absent|exists: ... }, ... ]
+        │
+        ▼  check("body_jsonpath", entries, resp)        (conformance_assertions.ex)
+        │     │ decode body once  (Bier.json_library)
+        │     ▼
+        │   ConformanceJsonPath.fetch(decoded, path)     (conformance_json_path.ex)
+        │     parse(path) → [segment]  →  resolve(segments, decoded)
+        │     ▼
+        │   {:ok, value} | :missing
+        ▼
+   predicate check (equals == / present|exists / absent)  → pass | flunk
+```
+
+### Components (all test-only)
+
+| File | Responsibility |
+| --- | --- |
+| `test/support/conformance_json_path.ex` (new) | `Bier.ConformanceJsonPath`: `parse/1` (string → segment list, raises on malformed), `resolve/2` (segments × term → `{:ok, value} \| :missing`), and `fetch/2` (string × term → same) as the public seam. Pure; no deps. |
+| `test/support/conformance_assertions.ex` (edit) | Add a `check("body_jsonpath", entries, resp)` clause before the catch-all raise. Reuses `decode_json/1`. |
+| `test/conformance/conformance_test.exs` (edit) | Remove the `Map.has_key?(c.expect, "body_jsonpath") -> :jsonpath` arm of `pending_reason` so these cases run. |
+
+No `lib/` or `mix.exs` changes (no new dependency).
+
+## 4. The JSONPath subset
+
+### Grammar (exactly what the 39 cases use)
+
+```
+path     = "$" *segment
+segment  = "." ident            ; dot member
+         | "[" "'" str "'" "]"  ; bracket string key
+         | "[" int "]"          ; array index
+ident    = (ALPHA / "_") *(ALPHA / DIGIT / "_")
+str      = *(any char except "'")     ; e.g. "/child_entities", "$ref", "200"
+int      = 1*DIGIT
+```
+
+A bracket key (`['200']`) is a **string map key**; a bare bracket integer
+(`[0]`) is an **array index** — the parse distinguishes them, so `responses['200']`
+and `tags[0]` resolve correctly. No escaping inside `'...'` is required (no
+embedded quotes occur in the corpus); the parser reads to the next `'`.
+
+### Segment representation
+
+```elixir
+@type segment :: {:key, String.t()} | {:index, non_neg_integer()}
+
+parse("$.paths['/child_entities'].get.responses['200'].description")
+#=> [{:key, "paths"}, {:key, "/child_entities"}, {:key, "get"},
+#    {:key, "responses"}, {:key, "200"}, {:key, "description"}]
+```
+
+`$` alone parses to `[]` and resolves to the whole body (not used by any case,
+but well-defined).
+
+### resolve/2 semantics
+
+Walk the decoded term left to right:
+
+- `{:key, k}` — if the current node is a map with key `k`, descend; else `:missing`.
+- `{:index, i}` — if the current node is a list with `i < length`, descend
+  (`Enum.at/2`); else `:missing`.
+- Type mismatch (key on a list, index on a map) — `:missing`.
+
+Returns `{:ok, value}` after the last segment, or `:missing` if any step fails.
+`:missing` is a first-class result, never an exception — it is exactly what the
+`absent`/`present` predicates test.
+
+## 5. Matcher (`check("body_jsonpath", entries, resp)`)
+
+`entries` is the list of `%{"path" => p, <predicate> => v}` maps. Decode the body
+once via `decode_json/1`, then for each entry resolve `fetch(decoded, p)` and
+apply its single predicate:
+
+| Predicate | Passes when |
+| --- | --- |
+| `equals: V` | `fetch == {:ok, actual}` **and** `actual == V` |
+| `present: true` | `fetch == {:ok, _}` |
+| `exists: true` | `fetch == {:ok, _}` (synonym of `present`) |
+| `absent: true` | `fetch == :missing` |
+
+- **`equals` uses plain `==` on decoded terms**, identical to the existing
+  `body_exact`/`body_json` checks — same house semantics, including for nested
+  objects/arrays (`{format: "json[]", type: "array", items: {type: "string"}}`).
+  Expected values are YAML-decoded (string keys, scalars, lists, maps), matching
+  the JSON-decoded actual. (If int/float skew between the YAML and JSON decoders
+  ever surfaces, normalize then — not anticipated for the current corpus.)
+- A failing entry produces a clear `flunk` naming the **path**, the **expected**
+  predicate/value, and the **actual** (`{:ok, value}` or `missing`).
+
+## 6. Error handling
+
+- **Malformed path** (e.g. unterminated `['…`, stray chars) — `parse/1` raises
+  `ArgumentError` naming the offending path. Surfaces a spec-authoring typo at
+  the assertion site rather than mis-navigating.
+- **Unknown predicate key** (anything other than `equals`/`present`/`exists`/
+  `absent` in an entry) — raises, consistent with the module's existing
+  "unsupported assertion key" rule: a case never passes by ignoring an assertion.
+- **Body not valid JSON** — reuses `decode_json/1`, which `flunk`s with the body.
+- **Entry without a `path`** — raises (malformed case).
+
+## 7. Test plan (TDD)
+
+Unit tests for `Bier.ConformanceJsonPath` (no HTTP, pure):
+
+- `parse/1`: dot keys, bracket string keys (`/`, `$ref`, `200`), array indices,
+  mixed chains; `$`-only; malformed inputs raise.
+- `resolve/2` & `fetch/2`: hit (`{:ok, v}`), miss on absent key, miss on
+  out-of-range index, miss on type mismatch, nested objects/arrays, whole-body
+  for `$`.
+
+Matcher tests for `assert_expect` with `body_jsonpath`: each predicate passing
+and failing against a fixture map; unknown-predicate raises; non-JSON body
+flunks. Then remove the `:jsonpath` pending arm and run the suite: the 11
+non-openapi cases are expected green (or surface real lib bugs to file); the 28
+openapi cases stay red pending #39 and are noted, not re-hidden.
+
+## 8. Out of scope / relationships
+
+- **OpenAPI document generation (#39)** — the 28 openapi cases depend on it; this
+  work only makes them assertable.
+- **JSONPath features beyond the subset** (filters, recursion, wildcards,
+  slices) — not implemented; the `fetch/2` seam allows swapping in a library if a
+  future case ever needs them. `parse/1` raises on such syntax rather than
+  silently ignoring it.
+- No changes to `lib/`, no runtime dependency, no `mix.exs` change.
+
+## 9. Branch note
+
+Work proceeds in the `worktree-jsonpath-conformance-assertions` worktree
+(branch off `main`), isolated from the in-flight telemetry PR (#37). All writes
+are `test/support/**` and the conformance generator — within the test harness.

--- a/test/bier/conformance_assertions_test.exs
+++ b/test/bier/conformance_assertions_test.exs
@@ -146,4 +146,8 @@ defmodule Bier.ConformanceAssertionsTest do
       assert_expect(r, %{"body_jsonpath" => [%{"path" => "$.a", "bogus" => true}]})
     end
   end
+
+  test "body_jsonpath with an empty entry list passes (no body decode)" do
+    assert_expect(resp(%{body: ""}), %{"body_jsonpath" => []})
+  end
 end

--- a/test/bier/conformance_assertions_test.exs
+++ b/test/bier/conformance_assertions_test.exs
@@ -95,4 +95,55 @@ defmodule Bier.ConformanceAssertionsTest do
     assert_expect(resp(%{body: ""}), %{"body_exact" => ""})
     assert_raise ExUnit.AssertionError, fn -> assert_expect(resp(), %{"body_exact" => nil}) end
   end
+
+  test "body_jsonpath equals (incl. null), present, exists, absent" do
+    body =
+      ~s({"code":"PGRST106","details":null,"swagger":"2.0",) <>
+        ~s("paths":{"/x":{"get":{"tags":["t0"]}}}})
+
+    r = resp(%{body: body})
+
+    assert_expect(r, %{
+      "body_jsonpath" => [
+        %{"path" => "$.code", "equals" => "PGRST106"},
+        %{"path" => "$.details", "equals" => nil},
+        %{"path" => "$.paths['/x'].get.tags[0]", "equals" => "t0"},
+        %{"path" => "$.swagger", "present" => true},
+        %{"path" => "$.swagger", "exists" => true},
+        %{"path" => "$.paths['/missing']", "absent" => true}
+      ]
+    })
+  end
+
+  test "body_jsonpath equals mismatch fails" do
+    r = resp(%{body: ~s({"code":"PGRST106"})})
+
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_expect(r, %{"body_jsonpath" => [%{"path" => "$.code", "equals" => "OTHER"}]})
+    end
+  end
+
+  test "body_jsonpath absent fails when the node is present" do
+    r = resp(%{body: ~s({"a":1})})
+
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_expect(r, %{"body_jsonpath" => [%{"path" => "$.a", "absent" => true}]})
+    end
+  end
+
+  test "body_jsonpath present fails when the node is missing" do
+    r = resp(%{body: ~s({"a":1})})
+
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_expect(r, %{"body_jsonpath" => [%{"path" => "$.b", "present" => true}]})
+    end
+  end
+
+  test "body_jsonpath unknown predicate raises (never silently passes)" do
+    r = resp(%{body: ~s({"a":1})})
+
+    assert_raise RuntimeError, ~r/unsupported body_jsonpath predicate/, fn ->
+      assert_expect(r, %{"body_jsonpath" => [%{"path" => "$.a", "bogus" => true}]})
+    end
+  end
 end

--- a/test/bier/conformance_json_path_test.exs
+++ b/test/bier/conformance_json_path_test.exs
@@ -47,4 +47,49 @@ defmodule Bier.ConformanceJsonPathTest do
       assert_raise ArgumentError, fn -> JP.parse("$['']") end
     end
   end
+
+  describe "resolve/2" do
+    @doc_term %{
+      "swagger" => "2.0",
+      "info" => %{"title" => "API"},
+      "details" => nil,
+      "paths" => %{"/x" => %{"get" => %{"tags" => ["a", "b"]}}},
+      "list" => [%{"Plan" => 1}]
+    }
+
+    test "whole document for empty segments" do
+      assert JP.resolve([], @doc_term) == {:ok, @doc_term}
+    end
+
+    test "nested key hit" do
+      assert JP.resolve([{:key, "info"}, {:key, "title"}], @doc_term) == {:ok, "API"}
+    end
+
+    test "key present with null value is a hit (not missing)" do
+      assert JP.resolve([{:key, "details"}], @doc_term) == {:ok, nil}
+    end
+
+    test "bracket-keyed path and array index" do
+      assert JP.resolve(
+               [{:key, "paths"}, {:key, "/x"}, {:key, "get"}, {:key, "tags"}, {:index, 1}],
+               @doc_term
+             ) == {:ok, "b"}
+
+      assert JP.resolve([{:index, 0}, {:key, "Plan"}], @doc_term["list"]) == {:ok, 1}
+    end
+
+    test "missing key, out-of-range index, and type mismatch are :missing" do
+      assert JP.resolve([{:key, "nope"}], @doc_term) == :missing
+      assert JP.resolve([{:key, "list"}, {:index, 9}], @doc_term) == :missing
+      assert JP.resolve([{:key, "swagger"}, {:key, "x"}], @doc_term) == :missing
+    end
+  end
+
+  describe "fetch/2" do
+    test "parses then resolves" do
+      term = %{"a" => %{"b" => [10, 20]}}
+      assert JP.fetch(term, "$.a.b[1]") == {:ok, 20}
+      assert JP.fetch(term, "$.a.c") == :missing
+    end
+  end
 end

--- a/test/bier/conformance_json_path_test.exs
+++ b/test/bier/conformance_json_path_test.exs
@@ -1,0 +1,50 @@
+defmodule Bier.ConformanceJsonPathTest do
+  use ExUnit.Case, async: true
+
+  alias Bier.ConformanceJsonPath, as: JP
+
+  describe "parse/1" do
+    test "root only" do
+      assert JP.parse("$") == []
+    end
+
+    test "dot members" do
+      assert JP.parse("$.code") == [{:key, "code"}]
+      assert JP.parse("$.info.title") == [{:key, "info"}, {:key, "title"}]
+      assert JP.parse("$.a_json") == [{:key, "a_json"}]
+    end
+
+    test "bracket string keys (slash, dollar, digits)" do
+      assert JP.parse("$.paths['/child_entities']") ==
+               [{:key, "paths"}, {:key, "/child_entities"}]
+
+      assert JP.parse("$.x['$ref']") == [{:key, "x"}, {:key, "$ref"}]
+      assert JP.parse("$.responses['200']") == [{:key, "responses"}, {:key, "200"}]
+    end
+
+    test "array indices" do
+      assert JP.parse("$[0].Plan") == [{:index, 0}, {:key, "Plan"}]
+      assert JP.parse("$.tags[0]") == [{:key, "tags"}, {:index, 0}]
+    end
+
+    test "mixed chain" do
+      assert JP.parse("$.paths['/child_entities'].get.responses['200'].description") ==
+               [
+                 {:key, "paths"},
+                 {:key, "/child_entities"},
+                 {:key, "get"},
+                 {:key, "responses"},
+                 {:key, "200"},
+                 {:key, "description"}
+               ]
+    end
+
+    test "malformed paths raise ArgumentError" do
+      assert_raise ArgumentError, fn -> JP.parse("code") end
+      assert_raise ArgumentError, fn -> JP.parse("$.") end
+      assert_raise ArgumentError, fn -> JP.parse("$['unterminated") end
+      assert_raise ArgumentError, fn -> JP.parse("$[]") end
+      assert_raise ArgumentError, fn -> JP.parse("$['']") end
+    end
+  end
+end

--- a/test/conformance/conformance_test.exs
+++ b/test/conformance/conformance_test.exs
@@ -4,9 +4,10 @@ defmodule Bier.ConformanceTest do
   against the shared Bier instance and currently FAIL (lib/ returns canned
   responses). Cases the current harness cannot evaluate are tagged :pending and
   excluded (see pending_reason): :cli (no CLI), :jwt (needs JWT signing),
-  :jsonpath (needs a JSONPath evaluator), :status_text (req does not expose the
-  HTTP reason phrase). These are tracked for a follow-up, like the schema_cache
-  deferral in spec/COVERAGE.md.
+  :openapi_doc (openapi body_jsonpath cases need the generated OpenAPI
+  document, #39), :status_text (req does not expose the HTTP reason phrase).
+  These are tracked for a follow-up, like the schema_cache deferral in
+  spec/COVERAGE.md.
   """
   use Bier.HttpCase, async: true
 
@@ -15,11 +16,23 @@ defmodule Bier.ConformanceTest do
   for c <- Bier.ConformanceCase.load_all() do
     pending_reason =
       cond do
-        c.kind == :cli -> :cli
-        Map.has_key?(c.request, "jwt") -> :jwt
-        Map.has_key?(c.expect, "body_jsonpath") -> :jsonpath
-        Map.has_key?(c.expect, "status_text") -> :status_text
-        true -> nil
+        c.kind == :cli ->
+          :cli
+
+        Map.has_key?(c.request, "jwt") ->
+          :jwt
+
+        # body_jsonpath now evaluates (see Bier.ConformanceJsonPath), EXCEPT the
+        # openapi-area cases, which assert the generated OpenAPI document that is
+        # still a stub until #39. Keep those excluded under an honest reason.
+        Map.has_key?(c.expect, "body_jsonpath") and c.area == "openapi" ->
+          :openapi_doc
+
+        Map.has_key?(c.expect, "status_text") ->
+          :status_text
+
+        true ->
+          nil
       end
 
     @tag area: String.to_atom(c.area)

--- a/test/support/conformance_assertions.ex
+++ b/test/support/conformance_assertions.ex
@@ -98,8 +98,41 @@ defmodule Bier.ConformanceAssertions do
     end)
   end
 
+  defp check("body_jsonpath", entries, resp) when is_list(entries) do
+    decoded = decode_json(resp.body)
+    Enum.each(entries, &check_jsonpath_entry(&1, decoded))
+  end
+
   defp check(key, _val, _resp) do
     raise "unsupported assertion key: #{inspect(key)}"
+  end
+
+  defp check_jsonpath_entry(%{"path" => path} = entry, decoded) do
+    result = Bier.ConformanceJsonPath.fetch(decoded, path)
+
+    cond do
+      Map.has_key?(entry, "equals") ->
+        expected = Map.fetch!(entry, "equals")
+
+        assert result == {:ok, expected},
+               "body_jsonpath #{path} equals mismatch:\n" <>
+                 "  expected: #{inspect(expected)}\n  got:      #{inspect(result)}"
+
+      Map.get(entry, "present") == true or Map.get(entry, "exists") == true ->
+        assert match?({:ok, _}, result),
+               "body_jsonpath #{path} expected to be present, got: #{inspect(result)}"
+
+      Map.get(entry, "absent") == true ->
+        assert result == :missing,
+               "body_jsonpath #{path} expected to be absent, got: #{inspect(result)}"
+
+      true ->
+        raise "unsupported body_jsonpath predicate in entry: #{inspect(entry)}"
+    end
+  end
+
+  defp check_jsonpath_entry(entry, _decoded) do
+    raise "body_jsonpath entry missing \"path\": #{inspect(entry)}"
   end
 
   defp decode_json(body) do

--- a/test/support/conformance_assertions.ex
+++ b/test/support/conformance_assertions.ex
@@ -98,6 +98,8 @@ defmodule Bier.ConformanceAssertions do
     end)
   end
 
+  defp check("body_jsonpath", [], _resp), do: :ok
+
   defp check("body_jsonpath", entries, resp) when is_list(entries) do
     decoded = decode_json(resp.body)
     Enum.each(entries, &check_jsonpath_entry(&1, decoded))

--- a/test/support/conformance_json_path.ex
+++ b/test/support/conformance_json_path.ex
@@ -75,4 +75,28 @@ defmodule Bier.ConformanceJsonPath do
   defp take_until_quote("", _acc), do: :unterminated
 
   defp bad(orig), do: raise(ArgumentError, "malformed JSONPath: #{inspect(orig)}")
+
+  @doc "Resolve parsed `segments` against a decoded JSON term."
+  @spec resolve([segment()], term()) :: {:ok, term()} | :missing
+  def resolve([], term), do: {:ok, term}
+
+  def resolve([{:key, k} | rest], term) when is_map(term) do
+    case Map.fetch(term, k) do
+      {:ok, value} -> resolve(rest, value)
+      :error -> :missing
+    end
+  end
+
+  def resolve([{:index, i} | rest], term) when is_list(term) do
+    case Enum.fetch(term, i) do
+      {:ok, value} -> resolve(rest, value)
+      :error -> :missing
+    end
+  end
+
+  def resolve(_segments, _term), do: :missing
+
+  @doc "Parse `path` and resolve it against `term`."
+  @spec fetch(term(), String.t()) :: {:ok, term()} | :missing
+  def fetch(term, path), do: path |> parse() |> resolve(term)
 end

--- a/test/support/conformance_json_path.ex
+++ b/test/support/conformance_json_path.ex
@@ -1,0 +1,78 @@
+defmodule Bier.ConformanceJsonPath do
+  @moduledoc """
+  A deterministic, single-match JSONPath subset for the conformance harness's
+  `expect.body_jsonpath` assertions.
+
+  Supports exactly the grammar the conformance cases use — root `$`, dot member
+  `.key`, bracket string key `['key']` (keys may contain `/`, `$`, digits), and
+  array index `[n]`. It deliberately does NOT support filters (`?()`), recursive
+  descent (`..`), wildcards (`[*]`/`.*`), or slices; such syntax raises rather
+  than being silently ignored. Inputs are trusted (our own checked-in spec
+  files), so the parser fails fast on a malformed path to surface authoring
+  typos at the assertion site.
+  """
+
+  @type segment :: {:key, String.t()} | {:index, non_neg_integer()}
+
+  @doc """
+  Parse a path string into a list of segments. Raises `ArgumentError` on a
+  malformed path. `"$"` parses to `[]` (the whole document).
+  """
+  @spec parse(String.t()) :: [segment()]
+  def parse("$" <> rest), do: parse_segments(rest, [], "$" <> rest)
+  def parse(path), do: raise(ArgumentError, "JSONPath must start with $: #{inspect(path)}")
+
+  defp parse_segments("", acc, _orig), do: Enum.reverse(acc)
+
+  # .identifier
+  defp parse_segments("." <> rest, acc, orig) do
+    {ident, rest} = take_ident(rest, "")
+    if ident == "", do: bad(orig)
+    parse_segments(rest, [{:key, ident} | acc], orig)
+  end
+
+  # ['quoted string']  (must be tried before the bare-"[" clause below)
+  defp parse_segments("['" <> rest, acc, orig) do
+    case take_until_quote(rest, "") do
+      {"", _} -> bad(orig)
+      {key, "]" <> rest2} -> parse_segments(rest2, [{:key, key} | acc], orig)
+      _ -> bad(orig)
+    end
+  end
+
+  # [integer]
+  defp parse_segments("[" <> rest, acc, orig) do
+    case take_digits(rest, "") do
+      {"", _} ->
+        bad(orig)
+
+      {digits, "]" <> rest2} ->
+        parse_segments(rest2, [{:index, String.to_integer(digits)} | acc], orig)
+
+      _ ->
+        bad(orig)
+    end
+  end
+
+  defp parse_segments(_other, _acc, orig), do: bad(orig)
+
+  defp take_ident(<<c, rest::binary>>, acc)
+       when c in ?a..?z or c in ?A..?Z or c in ?0..?9 or c == ?_,
+       do: take_ident(rest, acc <> <<c>>)
+
+  defp take_ident(rest, acc), do: {acc, rest}
+
+  defp take_digits(<<c, rest::binary>>, acc) when c in ?0..?9,
+    do: take_digits(rest, acc <> <<c>>)
+
+  defp take_digits(rest, acc), do: {acc, rest}
+
+  # Read until the closing single quote. No escaping is needed for the corpus;
+  # an unterminated quote returns :unterminated, which the caller turns into a
+  # parse error.
+  defp take_until_quote("'" <> rest, acc), do: {acc, rest}
+  defp take_until_quote(<<c, rest::binary>>, acc), do: take_until_quote(rest, acc <> <<c>>)
+  defp take_until_quote("", _acc), do: :unterminated
+
+  defp bad(orig), do: raise(ArgumentError, "malformed JSONPath: #{inspect(orig)}")
+end

--- a/test/support/conformance_server.ex
+++ b/test/support/conformance_server.ex
@@ -32,7 +32,7 @@ defmodule Bier.ConformanceServer do
   # `base_opts/0` and stay on the shared instance — routing a currently-passing
   # case to a faithful variant could change its result. (1467 RS256 is deferred,
   # issue #23; openapi-mode/db-root-spec behavior lands separately.)
-  @variant_case_ids [1491, 1493, 1678, 1682, 1758, 1763]
+  @variant_case_ids [1491, 1493, 1678, 1682, 1703, 1758, 1763]
 
   def url_for(%Bier.ConformanceCase{id: id}) when id in @variant_case_ids,
     do: :persistent_term.get({__MODULE__, :variant, id})
@@ -61,8 +61,13 @@ defmodule Bier.ConformanceServer do
   # Translate a PostgREST per-case `config:` map into `Bier.start_link/1` opts:
   # `kebab-case` keys become the matching snake_case atoms; values pass through
   # as parsed from YAML (`null` -> nil, `false`, `""`, strings).
+  # Special case: `db-schemas` in YAML may be a plain scalar string (e.g. "test")
+  # when only one schema is listed; wrap it in a list so NimbleOptions accepts it.
   defp translate(config) do
-    Enum.map(config, fn {k, v} -> {k |> String.replace("-", "_") |> String.to_atom(), v} end)
+    Enum.map(config, fn
+      {"db-schemas", v} when is_binary(v) -> {:db_schemas, [v]}
+      {k, v} -> {k |> String.replace("-", "_") |> String.to_atom(), v}
+    end)
   end
 
   @doc """


### PR DESCRIPTION
## Summary

Adds a small, **dependency-free** JSONPath-subset evaluator plus a `body_jsonpath` assertion matcher to the conformance harness, then enables the 11 non-openapi `body_jsonpath` cases that were previously excluded. This is the test-harness half of issue #38 (the single biggest driver of the conformance gap).

- `Bier.ConformanceJsonPath` (`test/support/conformance_json_path.ex`) — `parse/1` → `[{:key, ...} | {:index, ...}]`, `resolve/2` → `{:ok, value} | :missing`, `fetch/2`. Covers exactly the grammar the cases use (`$`, `.key`, `['key']`, `[n]`); filters/wildcards/recursion/slices raise rather than mis-navigate. `:missing` is first-class, so a present-but-null node (`{:ok, nil}`) is distinct from an absent one.
- `Bier.ConformanceAssertions` — new `body_jsonpath` clause: `equals` (plain `==`, consistent with `body_exact`), `present`/`exists`, `absent`; unknown predicate raises; an empty entry list skips body decoding (CORS preflight case 1703).
- Conformance generator — the broad `:jsonpath` pending arm becomes a narrow `:openapi_doc` arm: the 28 openapi cases stay excluded under an honest reason pointing at **#39** (they assert the generated OpenAPI document, still a stub), while the 11 non-openapi cases now run.
- `ConformanceServer` — routes case 1703 (CORS empty-origins) to a per-case config variant and wraps a scalar `db-schemas` YAML value into a list for NimbleOptions.

No `lib/` changes, **no new dependency**, no `mix.exs` change. Design/plan committed under `docs/superpowers/`.

### Why no JSONPath library / nimble_parsec
The needed path grammar is 4 deterministic rules (a ~20-line tokenizer); the matcher (`equals`/`present`/`absent`/`exists` + deep-equal) is bespoke regardless. The maintained Elixir JSONPath libs are stale/pre-RFC (exjsonpath 2020, warpath 2022) and the RFC-compliant one is days-old/pre-1.0 — a dependency would be higher long-term maintenance for the trivial half. `nimble_parsec` is kept dev-only by project convention. Full rationale in the design doc.

## Test Plan
- [x] `mix test test/bier/conformance_json_path_test.exs` — parse/resolve/fetch unit tests
- [x] `mix test test/bier/conformance_assertions_test.exs` — matcher unit tests
- [x] Full suite: `4 doctests, 505 tests, 4 failures (69 excluded)` — the 4 failures are the **pre-existing, unrelated** cases (1467 RS256 → #23; 1616–1618 geojson → #15). The 11 newly-enabled cases (1010, 1012, 1016, 1356, 1358, 1393, 1501, 1502, 1619, 1625, 1703) all pass.
- [x] `mix format --check-formatted`, `mix compile --warnings-as-errors` clean.

## Follow-up
- The 28 openapi `body_jsonpath` cases remain excluded under `:openapi_doc` until OpenAPI document generation lands (**#39**). This evaluator is the prerequisite that makes that work pay off.

Part of #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)