### PR TITLE
fix(observability): measure real per-phase Server-Timing durations (closes #32)

### DIFF
--- a/lib/bier/mutation.ex
+++ b/lib/bier/mutation.ex
@@ -171,41 +171,45 @@ defmodule Bier.Mutation do
     relations = :persistent_term.get({Bier, :relations, config.name}, %{})
 
     {:ok, wrapped, wparams} =
-      QueryExecutor.build_representation(relation, plan, relations, {sql, params})
+      Bier.ServerTiming.measure(:plan, fn ->
+        QueryExecutor.build_representation(relation, plan, relations, {sql, params})
+      end)
 
     result =
-      Postgrex.transaction(pool, fn tx ->
-        # pg-safeupdate parity: when this table is configured "safe", an UPDATE
-        # or DELETE without a filter must raise 21000.
-        maybe_enable_safeupdate(tx, config, relation, mutation, plan)
+      Bier.ServerTiming.measure(:transaction, fn ->
+        Postgrex.transaction(pool, fn tx ->
+          # pg-safeupdate parity: when this table is configured "safe", an UPDATE
+          # or DELETE without a filter must raise 21000.
+          maybe_enable_safeupdate(tx, config, relation, mutation, plan)
 
-        # For PUT, distinguish insert (201) from replace (200) by whether the PK
-        # already existed before the upsert.
-        existed = put_existed?(tx, relation, mutation)
+          # For PUT, distinguish insert (201) from replace (200) by whether the PK
+          # already existed before the upsert.
+          existed = put_existed?(tx, relation, mutation)
 
-        case Postgrex.query(tx, wrapped, wparams) do
-          {:ok, %Postgrex.Result{rows: [[body, count, meta]]}} ->
-            count = count || 0
+          case Postgrex.query(tx, wrapped, wparams) do
+            {:ok, %Postgrex.Result{rows: [[body, count, meta]]}} ->
+              count = count || 0
 
-            with :ok <- enforce_max_affected(pref, count),
-                 :ok <- enforce_singular(media, body),
-                 # Read any response.headers / response.status GUC an INSTEAD OF
-                 # trigger set during the write, BEFORE the transaction ends
-                 # (the GUCs are transaction-local; a rollback would discard them).
-                 {:ok, guc} <- Bier.Guc.read(tx) do
-              # The response is fully computed inside the transaction (the CTE's
-              # RETURNING is already serialized into `body`). Under db-tx-end
-              # :rollback we abort the transaction here, discarding the write but
-              # returning the same response — see the conformance harness's
-              # base_opts/0 (db_tx_end: :rollback) for why.
-              finish_tx(tx, config, {body, count, meta, existed, guc})
-            else
-              {:error, _} = err -> Postgrex.rollback(tx, err)
-            end
+              with :ok <- enforce_max_affected(pref, count),
+                   :ok <- enforce_singular(media, body),
+                   # Read any response.headers / response.status GUC an INSTEAD OF
+                   # trigger set during the write, BEFORE the transaction ends
+                   # (the GUCs are transaction-local; a rollback would discard them).
+                   {:ok, guc} <- Bier.Guc.read(tx) do
+                # The response is fully computed inside the transaction (the CTE's
+                # RETURNING is already serialized into `body`). Under db-tx-end
+                # :rollback we abort the transaction here, discarding the write but
+                # returning the same response — see the conformance harness's
+                # base_opts/0 (db_tx_end: :rollback) for why.
+                finish_tx(tx, config, {body, count, meta, existed, guc})
+              else
+                {:error, _} = err -> Postgrex.rollback(tx, err)
+              end
 
-          {:error, _} = err ->
-            Postgrex.rollback(tx, err)
-        end
+            {:error, _} = err ->
+              Postgrex.rollback(tx, err)
+          end
+        end)
       end)
 
     case result do

--- a/lib/bier/plan.ex
+++ b/lib/bier/plan.ex
@@ -18,10 +18,16 @@ defmodule Bier.Plan do
   def explain(conn, pool, relation, plan, %MediaType{symbol: :plan} = media) do
     {format, _} = {media.params.format, media.params}
 
-    with {:ok, sql, params} <- QueryExecutor.build(relation, plan, relations(conn)) do
+    with {:ok, sql, params} <-
+           Bier.ServerTiming.measure(:plan, fn ->
+             QueryExecutor.build(relation, plan, relations(conn))
+           end) do
       explain_sql = "EXPLAIN (#{explain_opts(format, media)}) " <> sql
 
-      case Postgrex.query(pool, explain_sql, params) do
+      Bier.ServerTiming.measure(:transaction, fn ->
+        Postgrex.query(pool, explain_sql, params)
+      end)
+      |> case do
         {:ok, %Postgrex.Result{rows: rows}} ->
           body = plan_body(format, rows)
 

--- a/lib/bier/plugs/action_controller.ex
+++ b/lib/bier/plugs/action_controller.ex
@@ -82,7 +82,7 @@ defmodule Bier.Plugs.ActionController do
   @doc false
   def maybe_auth(conn, config, schema) do
     if Bier.Auth.applicable?(schema) do
-      case Bier.Auth.resolve(conn, config) do
+      case Bier.ServerTiming.measure(:jwt, fn -> Bier.Auth.resolve(conn, config) end) do
         {:ok, context} -> {:ok, assign(conn, :bier_auth, context)}
         {:error, _} = err -> err
       end
@@ -159,7 +159,10 @@ defmodule Bier.Plugs.ActionController do
     fun =
       "#{Bier.QueryExecutor.quote_ident(schema)}.#{Bier.QueryExecutor.quote_ident(config.db_root_spec)}"
 
-    case Postgrex.query(Registry.via(config.name, Postgrex), "SELECT (#{fun}())::text", []) do
+    Bier.ServerTiming.measure(:transaction, fn ->
+      Postgrex.query(Registry.via(config.name, Postgrex), "SELECT (#{fun}())::text", [])
+    end)
+    |> case do
       {:ok, %Postgrex.Result{rows: [[body]]}} -> root_doc_body(conn, body)
       {:error, _} = err -> err
     end
@@ -466,10 +469,12 @@ defmodule Bier.Plugs.ActionController do
 
   @doc false
   def parse(conn, config) do
-    with {:ok, plan} <- QueryParser.parse_request(conn.query_string),
-         {:ok, plan} <- apply_range_header(conn, plan) do
-      {:ok, apply_max_rows(plan, config)}
-    end
+    Bier.ServerTiming.measure(:parse, fn ->
+      with {:ok, plan} <- QueryParser.parse_request(conn.query_string),
+           {:ok, plan} <- apply_range_header(conn, plan) do
+        {:ok, apply_max_rows(plan, config)}
+      end
+    end)
   end
 
   defp apply_range_header(conn, plan) do

--- a/lib/bier/plugs/observability.ex
+++ b/lib/bier/plugs/observability.ex
@@ -7,18 +7,23 @@ defmodule Bier.Plugs.Observability do
     * **Server-Timing** (`server-timing-enabled`): when enabled, every response
       carries a `Server-Timing` header with the per-phase durations PostgREST
       reports — `jwt`, `parse`, `plan`, `transaction`, `response` — each as
-      `<name>;dur=<ms>` with at least one decimal. `OPTIONS` responses carry
-      only the `jwt`, `parse`, `response` subset (no query plan / DB transaction
-      runs). When disabled the header is omitted entirely.
+      `<name>;dur=<ms>` with at least one decimal. The durations are *measured*:
+      each phase is timed at its real call site via `Bier.ServerTiming.measure/2`
+      and accumulated for the request; a phase that did no work for a given
+      request reports `0.0` (never a fabricated share of the total). `OPTIONS`
+      responses carry only the `jwt`, `parse`, `response` subset (no query plan /
+      DB transaction runs). When disabled the header is omitted entirely.
 
     * **Trace header passthrough** (`server-trace-header`): when configured with
       a header name (e.g. `X-Request-Id`), the incoming value of that header is
       echoed verbatim on the response. An empty/nil configuration is a no-op —
       the header is not echoed.
 
-  The header is computed in a `Plug.Conn.register_before_send/2` callback so the
-  total elapsed time (and therefore the `transaction` phase, which dominates for
-  slow queries) reflects the real request wall-clock. `log-level` is a
+  The header is written in a `Plug.Conn.register_before_send/2` callback, which
+  fires synchronously while the response is sent — at which point every phase the
+  request ran (recorded into `Bier.ServerTiming`'s process-scoped accumulator as
+  it went) is available, including `response`, since `Bier.Render` records its
+  rendering time before the caller calls `send_resp`. `log-level` is a
   logging-only concern and never alters the response, so it is not handled here.
   """
 
@@ -35,7 +40,11 @@ defmodule Bier.Plugs.Observability do
   def call(conn, _opts) do
     name = conn.assigns.supervisor_name
     config = Registry.config(name)
-    start = System.monotonic_time(:native)
+
+    # Initialise the per-phase accumulator for this request (and clear any phases
+    # left by a previous request on a keep-alive connection). Phases are only
+    # collected when server-timing is enabled.
+    Bier.ServerTiming.reset(config.server_timing_enabled)
 
     # `[:bier, :request, :start]` fires here; `:stop` fires in a before_send
     # callback so its duration is the real request wall-clock. The span is keyed
@@ -44,7 +53,7 @@ defmodule Bier.Plugs.Observability do
 
     conn
     |> echo_trace_header(config)
-    |> register_before_send(&put_server_timing(&1, config, start))
+    |> register_before_send(&put_server_timing(&1, config))
     |> register_before_send(&emit_request_stop(&1, name, request_start))
   end
 
@@ -83,66 +92,33 @@ defmodule Bier.Plugs.Observability do
 
   # ---- Server-Timing -------------------------------------------------------
 
-  defp put_server_timing(conn, %{server_timing_enabled: true} = _config, start) do
-    elapsed_ms = native_to_ms(System.monotonic_time(:native) - start)
-    put_resp_header(conn, "server-timing", timing_value(conn.method, elapsed_ms))
+  defp put_server_timing(conn, %{server_timing_enabled: true} = _config) do
+    value = timing_value(conn.method, Bier.ServerTiming.snapshot())
+    put_resp_header(conn, "server-timing", value)
   end
 
-  defp put_server_timing(conn, _config, _start), do: conn
+  defp put_server_timing(conn, _config), do: conn
 
   # OPTIONS does no query planning or DB transaction, so it reports only the
-  # jwt/parse/response subset (mirrors PostgREST's ServerTimingSpec).
-  defp timing_value("OPTIONS", elapsed_ms) do
-    response = small_phase(elapsed_ms)
+  # jwt/parse/response subset (mirrors PostgREST's ServerTimingSpec); `plan` and
+  # `transaction` are omitted entirely (not rendered as the substring at all).
+  defp timing_value("OPTIONS", phases), do: join(phases, [:jwt, :parse, :response])
 
-    join([
-      {"jwt", small_phase(elapsed_ms)},
-      {"parse", small_phase(elapsed_ms)},
-      {"response", response}
-    ])
-  end
+  # Every other method reports the full phase set, in PostgREST's fixed order.
+  # Each value is the measured duration of that phase for this request; a phase
+  # that ran no work reports 0.0.
+  defp timing_value(_method, phases),
+    do: join(phases, [:jwt, :parse, :plan, :transaction, :response])
 
-  # Every other method reports the full phase set. The `transaction` phase
-  # absorbs the bulk of the request's wall-clock (so a slow query — e.g. an RPC
-  # sleeping 2s — shows up there), while the lightweight phases get a small,
-  # always-positive share.
-  defp timing_value(_method, elapsed_ms) do
-    jwt = small_phase(elapsed_ms)
-    parse = small_phase(elapsed_ms)
-    plan = small_phase(elapsed_ms)
-    response = small_phase(elapsed_ms)
-    transaction = max(elapsed_ms - jwt - parse - plan - response, 0.001)
-
-    join([
-      {"jwt", jwt},
-      {"parse", parse},
-      {"plan", plan},
-      {"transaction", transaction},
-      {"response", response}
-    ])
-  end
-
-  # A tiny, always-non-zero per-phase share. Bounded so it never swallows the
-  # transaction phase on a fast request, and never grows large enough to push a
-  # slow request's transaction below its real duration band.
-  defp small_phase(elapsed_ms) do
-    elapsed_ms
-    |> Kernel.*(0.01)
-    |> min(0.5)
-    |> max(0.001)
-  end
-
-  defp join(phases) do
-    Enum.map_join(phases, ", ", fn {name, dur} -> "#{name};dur=#{format(dur)}" end)
+  defp join(phases, names) do
+    Enum.map_join(names, ", ", fn name ->
+      "#{name};dur=#{format(Map.get(phases, name, 0.0))}"
+    end)
   end
 
   # Render with at least one decimal digit so it always matches
   # `dur=[0-9]+\.[0-9]+` (PostgREST emits a fractional millisecond value).
   defp format(ms) do
     :erlang.float_to_binary(ms * 1.0, decimals: 3)
-  end
-
-  defp native_to_ms(native) do
-    System.convert_time_unit(native, :native, :nanosecond) / 1_000_000
   end
 end

--- a/lib/bier/query_executor.ex
+++ b/lib/bier/query_executor.ex
@@ -57,17 +57,29 @@ defmodule Bier.QueryExecutor do
     timezone = Keyword.get(opts, :timezone)
     auth = Keyword.get(opts, :auth)
 
-    with {:ok, sql, params} <- build(relation, plan, relations) do
-      case query_read(conn, sql, params, timezone, auth) do
-        {:ok, %Postgrex.Result{rows: [[body, exact_count]]}} ->
-          resolve_count(conn, relation, plan, relations, count_mode, opts, body, exact_count || 0)
+    with {:ok, sql, params} <-
+           Bier.ServerTiming.measure(:plan, fn -> build(relation, plan, relations) end) do
+      Bier.ServerTiming.measure(:transaction, fn ->
+        case query_read(conn, sql, params, timezone, auth) do
+          {:ok, %Postgrex.Result{rows: [[body, exact_count]]}} ->
+            resolve_count(
+              conn,
+              relation,
+              plan,
+              relations,
+              count_mode,
+              opts,
+              body,
+              exact_count || 0
+            )
 
-        {:ok, %Postgrex.Result{rows: []}} ->
-          {:ok, %{body: "[]", count: 0}}
+          {:ok, %Postgrex.Result{rows: []}} ->
+            {:ok, %{body: "[]", count: 0}}
 
-        {:error, _} = err ->
-          err
-      end
+          {:error, _} = err ->
+            err
+        end
+      end)
     end
   end
 
@@ -254,21 +266,25 @@ defmodule Bier.QueryExecutor do
     relations = Keyword.get(opts, :relations, %{})
 
     try do
-      case build_function(fn_def, ret_relation, args, plan, relations) do
+      case Bier.ServerTiming.measure(:plan, fn ->
+             build_function(fn_def, ret_relation, args, plan, relations)
+           end) do
         {:ok, sql, params} ->
-          case Postgrex.query(conn, sql, params) do
-            {:ok, %Postgrex.Result{rows: [[body, exact_count]]}} ->
-              # planned/estimated counts are not needed by the RPC pagination
-              # cases; exact reuses the window count, which (with a non-empty
-              # window) is the full count. Empty RPC windows are not exercised.
-              {:ok, %{body: body, count: count_for(count_mode, exact_count || 0)}}
+          Bier.ServerTiming.measure(:transaction, fn ->
+            case Postgrex.query(conn, sql, params) do
+              {:ok, %Postgrex.Result{rows: [[body, exact_count]]}} ->
+                # planned/estimated counts are not needed by the RPC pagination
+                # cases; exact reuses the window count, which (with a non-empty
+                # window) is the full count. Empty RPC windows are not exercised.
+                {:ok, %{body: body, count: count_for(count_mode, exact_count || 0)}}
 
-            {:ok, %Postgrex.Result{rows: []}} ->
-              {:ok, %{body: "[]", count: 0}}
+              {:ok, %Postgrex.Result{rows: []}} ->
+                {:ok, %{body: "[]", count: 0}}
 
-            {:error, _} = err ->
-              err
-          end
+              {:error, _} = err ->
+                err
+            end
+          end)
 
         {:error, _} = err ->
           err

--- a/lib/bier/render.ex
+++ b/lib/bier/render.ex
@@ -17,8 +17,16 @@ defmodule Bier.Render do
   plurality violation).
 
     * `:columns` — ordered column names used for CSV output.
+
+  The transform is timed as the `response` phase of `Server-Timing`
+  (`Bier.ServerTiming`); it runs before the caller calls `send_resp`, so the
+  duration is recorded in time for the header.
   """
-  def render(%MediaType{symbol: :singular} = mt, body, _opts) do
+  def render(media, body, opts) do
+    Bier.ServerTiming.measure(:response, fn -> do_render(media, body, opts) end)
+  end
+
+  defp do_render(%MediaType{symbol: :singular} = mt, body, _opts) do
     rows = decode(body)
 
     case rows do
@@ -27,19 +35,19 @@ defmodule Bier.Render do
     end
   end
 
-  def render(%MediaType{symbol: :array_strip}, body, _opts) do
+  defp do_render(%MediaType{symbol: :array_strip}, body, _opts) do
     rows = decode(body)
     {:ok, encode(Enum.map(rows, &strip_nulls/1))}
   end
 
-  def render(%MediaType{symbol: :csv}, body, opts) do
+  defp do_render(%MediaType{symbol: :csv}, body, opts) do
     rows = decode(body)
     columns = csv_columns(rows, Keyword.get(opts, :columns))
     {:ok, to_csv(rows, columns)}
   end
 
   # json / openapi / plan / other: pass through unchanged.
-  def render(_mt, body, _opts), do: {:ok, body}
+  defp do_render(_mt, body, _opts), do: {:ok, body}
 
   # ---- helpers -------------------------------------------------------------
 

--- a/lib/bier/rpc.ex
+++ b/lib/bier/rpc.ex
@@ -473,20 +473,22 @@ defmodule Bier.Rpc do
     read_only? = m in ["GET", "HEAD"]
     auth = ActionController.auth_setup(conn, instance_config(conn))
 
-    Postgrex.transaction(pool, fn tx ->
-      if read_only?, do: Postgrex.query!(tx, "SET TRANSACTION READ ONLY", [])
-      apply_auth(tx, auth)
+    Bier.ServerTiming.measure(:transaction, fn ->
+      Postgrex.transaction(pool, fn tx ->
+        if read_only?, do: Postgrex.query!(tx, "SET TRANSACTION READ ONLY", [])
+        apply_auth(tx, auth)
 
-      case Postgrex.query(tx, sql, params) do
-        {:ok, result} ->
-          case Bier.Guc.read(tx) do
-            {:ok, guc} -> {result, guc}
-            {:error, reason} -> Postgrex.rollback(tx, reason)
-          end
+        case Postgrex.query(tx, sql, params) do
+          {:ok, result} ->
+            case Bier.Guc.read(tx) do
+              {:ok, guc} -> {result, guc}
+              {:error, reason} -> Postgrex.rollback(tx, reason)
+            end
 
-        {:error, err} ->
-          Postgrex.rollback(tx, err)
-      end
+          {:error, err} ->
+            Postgrex.rollback(tx, err)
+        end
+      end)
     end)
     |> case do
       {:ok, {result, guc}} -> {:ok, result, guc}
@@ -522,10 +524,12 @@ defmodule Bier.Rpc do
       |> Enum.reject(fn {k, _v} -> MapSet.member?(arg_keys, k) end)
       |> URI.encode_query()
 
-    with {:ok, plan} <- QueryParser.parse_request(reserved_qs),
-         {:ok, plan} <- apply_range(conn, plan) do
-      {:ok, apply_max_rows(plan, config)}
-    end
+    Bier.ServerTiming.measure(:parse, fn ->
+      with {:ok, plan} <- QueryParser.parse_request(reserved_qs),
+           {:ok, plan} <- apply_range(conn, plan) do
+        {:ok, apply_max_rows(plan, config)}
+      end
+    end)
   end
 
   defp apply_range(conn, plan) do

--- a/lib/bier/server_timing.ex
+++ b/lib/bier/server_timing.ex
@@ -1,0 +1,94 @@
+defmodule Bier.ServerTiming do
+  @moduledoc """
+  Per-request accumulator for the real per-phase durations reported in the
+  `Server-Timing` response header (`Bier.Plugs.Observability`).
+
+  PostgREST measures each request phase — JWT verification, query-string parse,
+  SQL planning, the database transaction, and response rendering — and reports
+  them as named `Server-Timing` metrics. Bier mirrors that by timing each phase
+  *where the work actually happens* (`measure/2` wraps the real call site) and
+  accumulating the durations here, keyed to the current request.
+
+  ## Why the process dictionary
+
+  A request is handled start to finish — router pipeline, controller, query
+  executor, and the `Plug.Conn.register_before_send/2` callback that writes the
+  header — in a single Bandit process, and the phases are spread across modules
+  at different call depths. Threading a `Plug.Conn` accumulator through every one
+  would be invasive and, worse, *lossy*: error paths discard the inner conn (e.g.
+  `Bier.Plugs.ActionController` hands the original conn to the fallback
+  controller), so a JWT or parse timing measured on a request that then fails
+  would never reach the header. Process-scoped state survives those hand-offs and
+  is naturally request-scoped, since each request runs in its own process.
+
+  `reset/1` is called once at the top of the pipeline so a connection reused
+  across keep-alive requests never carries stale phases. Timing is collected only
+  when `server-timing-enabled` is set for the instance; otherwise `measure/2`
+  runs its function with no instrumentation and no process-dictionary writes.
+  """
+
+  @key {__MODULE__, :phases}
+
+  # `Server-Timing` durations are milliseconds (HTTP spec / PostgREST). Phases
+  # are accumulated as integer nanoseconds (`:timer.tc(_, :nanosecond)`) and
+  # converted here. Float division is deliberate: a phase can take well under a
+  # millisecond, and `:erlang.convert_time_unit/3` would truncate that to 0.
+  @ns_per_ms 1_000_000
+
+  @doc """
+  Initialise (or clear) the accumulator for the current request.
+
+  `enabled?` mirrors the instance's `server-timing-enabled`: when `false` the
+  accumulator is put into a disabled state so `measure/2` skips instrumentation
+  entirely. Called once per request by `Bier.Plugs.Observability`.
+  """
+  @spec reset(boolean()) :: :ok
+  def reset(true) do
+    Process.put(@key, %{})
+    :ok
+  end
+
+  def reset(false) do
+    Process.put(@key, :disabled)
+    :ok
+  end
+
+  @doc """
+  Time `fun`, accumulate its elapsed wall-clock under `phase`, and return its
+  result unchanged.
+
+  A no-op wrapper (just `fun.()`, no timing) when server-timing is disabled for
+  this request, or when called outside an initialised request. Repeated measures
+  of the same `phase` accumulate, so a phase that issues several round-trips
+  (e.g. a read plus an exact-count query) reports their sum.
+  """
+  @spec measure(atom(), (-> result)) :: result when result: var
+  def measure(phase, fun) when is_function(fun, 0) do
+    case Process.get(@key) do
+      phases when is_map(phases) ->
+        {elapsed, result} = :timer.tc(fun, :nanosecond)
+        Process.put(@key, Map.update(phases, phase, elapsed, &(&1 + elapsed)))
+        result
+
+      _ ->
+        fun.()
+    end
+  end
+
+  @doc """
+  The phases accumulated so far for the current request, as a map of
+  `phase => milliseconds` (float). Empty when timing is disabled or nothing was
+  recorded — `Bier.Plugs.Observability` reports a phase absent from this map as
+  `0.0` (truthful: no time was spent there) rather than a fabricated value.
+  """
+  @spec snapshot() :: %{optional(atom()) => float()}
+  def snapshot do
+    case Process.get(@key) do
+      phases when is_map(phases) ->
+        Map.new(phases, fn {phase, ns} -> {phase, ns / @ns_per_ms} end)
+
+      _ ->
+        %{}
+    end
+  end
+end

--- a/lib/bier/telemetry.ex
+++ b/lib/bier/telemetry.ex
@@ -32,10 +32,11 @@ defmodule Bier.Telemetry do
       document, `OPTIONS`, and error responses that never resolve a relation).
 
   > #### Per-phase timings {: .info}
-  > These events carry only the **total** request duration. The per-phase
-  > splits (jwt / parse / plan / transaction / response) that `Server-Timing`
-  > reports are still fabricated today; threading real per-phase timings through
-  > the pipeline is tracked as the Server-Timing fidelity follow-up (#26).
+  > These events carry only the **total** request duration. The per-phase splits
+  > (jwt / parse / plan / transaction / response) are measured separately and
+  > surfaced through the `Server-Timing` response header — see
+  > `Bier.ServerTiming` and `Bier.Plugs.Observability`. They are not (yet)
+  > attached to these `:telemetry` events.
 
   ### `[:bier, :schema_cache, :load, :start | :stop | :exception]`
 


### PR DESCRIPTION
## Summary

Fixes #32. `Bier.Plugs.Observability` emitted a well-formed `Server-Timing` header, but four of the five per-phase durations (`jwt`/`parse`/`plan`/`response`) were **fabricated** — each was `clamp(elapsed * 0.01, 0.001, 0.5)`, a fixed fraction of total wall-clock unrelated to the time actually spent in that phase. Only `transaction` (the remainder) was approximately real. The conformance suite asserts only header format, metric set/order, and the transaction band, so the invented values passed undetected.

## Approach

New module **`Bier.ServerTiming`** — a request-scoped accumulator (`reset/1`, `measure/2`, `snapshot/0`) backed by the process dictionary.

Process scope is the deliberate choice: the phases are spread across modules at different call depths, and error paths discard the inner `conn` (the fallback controller receives the *original* conn), so a conn-threaded accumulator would lose timings the header must still report. Each request is handled in a single Bandit process, so process scope is exactly request scope. `reset/1` at the top of the pipeline clears phases left by a prior keep-alive request; timing is collected only when `server-timing-enabled` is set.

Each phase is now timed at its **real call site**:

| Phase | Call site |
|-------|-----------|
| `jwt` | `Auth.resolve` (`ActionController.maybe_auth`) |
| `parse` | `ActionController.parse`, `Rpc.parse_plan` |
| `plan` | `QueryExecutor.build` / `build_function` / `build_representation`, `Plan` EXPLAIN build |
| `transaction` | the DB round-trips in `QueryExecutor`, `Mutation`, `Rpc.exec`, root-spec, `Plan` |
| `response` | `Bier.Render.render` — runs *before* `send_resp`, so the duration is recorded before the `before_send` callback writes the header |

`Observability` renders from the snapshot; a phase that did no work reports `0.0` (truthful) rather than a fabricated share. `OPTIONS` still emits only the `jwt`/`parse`/`response` subset. The `small_phase/1` fabrication is removed, and the `Telemetry` moduledoc note that tracked this as a follow-up is updated.

## Verification

- **18/18** observability conformance cases pass — including **1759** (2s-sleep RPC, whose `transaction` must land in `[2000, 3000)`ms, directly validating real measurement).
- **Full suite: 523 tests, 3 failures** — the geojson cases `1616`/`1617`/`1618`, confirmed **pre-existing** (they fail identically on `origin/main`: no PostGIS, `fixtures.sql` has no `shops` table). **Zero regressions.**
- **Direct empirical check** (throwaway, not committed): distinct sleeps per phase produced distinct measured values (parse 5.9ms, plan 21.1ms, transaction 81ms — a 13.6:1 ratio, not the fabricated 1:1); accumulation sums; disabled is a pass-through.
- CI gates pass: `format --check`, `deps.unlock --check-unused`, `hex.audit`, `compile --warnings-as-errors`, `docs --warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)