### PR TITLE
feat(#40): standalone drop-in PostgREST-compatible CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 bier-*.tar
 
+# Ignore the escript binary (built via "mix escript.build").
+/bier
+
 # Temporary files, for example, from tests.
 /tmp/
 

--- a/docs/superpowers/plans/2026-06-07-cli-implementation.md
+++ b/docs/superpowers/plans/2026-06-07-cli-implementation.md
@@ -1,0 +1,1379 @@
+# Bier CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Bier a standalone, drop-in PostgREST-compatible command-line interface (config from `PGRST_*` env, kebab-case config file, and flags; `--dump-config`; validation) so the `kind: cli` conformance cases that map onto config Bier actually implements turn green, and Bier can run as a standalone service.
+
+**Architecture:** A pure, testable core `Bier.CLI.run/2` (no IO, no `System.halt`) translates the PostgREST config dialect into Bier's internal `Bier.Config` atoms via `Bier.CLI.Config`, validating with the same checks `Bier.start_link/1` uses. A thin escript `Bier.CLI.main/1` wraps the core with real IO/exit. The conformance harness calls the core in-process.
+
+**Tech Stack:** Elixir, NimbleOptions (existing schema), ExUnit, YamlElixir (existing, conformance cases). No new runtime deps.
+
+**Scope notes (deliberate, per approved design doc `docs/superpowers/specs/2026-06-07-cli-implementation-design.md`):**
+- **In:** `Bier.CLI.run/2` core, `Bier.CLI.Config` (mapping/load/dump), `Bier.CLI.ConfigFile` parser, shared validators, escript wrapper, conformance CLI harness path.
+- **Deferred to a follow-up issue:** `mix release` + Dockerfile; `--ready` (client command against a running daemon — no conformance case, best smoke-tested with the release); `--example` (case 1727, `:cli_parity`); `db-config` DB-settings source (1724/1725); unmodeled keys (1711/1714/1715/1716/1718/1729).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `lib/bier/config.ex` (modify) | Add shared value validators `validate_jwt_secret/1`, `validate_jwt_aud/1`; call them from `new!/2`. |
+| `lib/bier/cli/config_file.ex` (create) | `Bier.CLI.ConfigFile.parse/1` — parse the `key = value` config-file subset. |
+| `lib/bier/cli/config.ex` (create) | `Bier.CLI.Config` — the PostgREST↔Bier mapping table, `load/3`, `dump/1`, `to_start_opts/1`, coercion helpers. |
+| `lib/bier/cli.ex` (create) | `Bier.CLI` — `run/2` core + dispatch, `main/1` escript wrapper. |
+| `mix.exs` (modify) | `escript: [main_module: Bier.CLI, app: nil]`. |
+| `test/support/cli_case.ex` (create) | `Bier.CliCase.perform/1` — drive a `kind: cli` case through `Bier.CLI.run/2`. |
+| `test/support/conformance_assertions.ex` (modify) | Add `exit_code`, `dump_contains`, `stderr_contains`, `dump_reparse_stable` clauses. |
+| `test/conformance/conformance_test.exs` (modify) | Dispatch `kind: cli` cases to the CLI path; defer only by explicit ID list. |
+| `test/bier/config_test.exs` (create) | Unit tests for the shared validators. |
+| `test/bier/cli/config_file_test.exs` (create) | Unit tests for the file parser. |
+| `test/bier/cli/config_test.exs` (create) | Unit tests for mapping/load/dump/coercion. |
+| `test/bier/cli_test.exs` (create) | Unit tests for `run/2` dispatch. |
+
+---
+
+## Task 1: Shared value validators in `Bier.Config`
+
+Adds the two semantic validators the library and CLI share: JWT secret minimum length (case 1708) and JWT audience URI (case 1709). `admin-server-port` (1717) is already validated in `new!/2`.
+
+**Files:**
+- Modify: `lib/bier/config.ex`
+- Test: `test/bier/config_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/bier/config_test.exs`:
+
+```elixir
+defmodule Bier.ConfigTest do
+  use ExUnit.Case, async: true
+
+  describe "validate_jwt_secret/1" do
+    test "nil and >= 32 chars are ok" do
+      assert Bier.Config.validate_jwt_secret(nil) == :ok
+      assert Bier.Config.validate_jwt_secret(String.duplicate("a", 32)) == :ok
+    end
+
+    test "shorter than 32 chars is rejected with PostgREST's message" do
+      assert Bier.Config.validate_jwt_secret("short_secret") ==
+               {:error, "The JWT secret must be at least 32 characters long."}
+    end
+  end
+
+  describe "validate_jwt_aud/1" do
+    test "nil and a plain string are ok" do
+      assert Bier.Config.validate_jwt_aud(nil) == :ok
+      assert Bier.Config.validate_jwt_aud("my-audience") == :ok
+    end
+
+    test "a value containing ':' must be a valid URI" do
+      assert Bier.Config.validate_jwt_aud("https://example.com/aud") == :ok
+
+      assert Bier.Config.validate_jwt_aud("foo://%%$$^^.com") ==
+               {:error, "jwt-aud should be a string or a valid URI"}
+    end
+  end
+
+  describe "new!/2 enforces the validators" do
+    test "a too-short jwt_secret raises" do
+      assert_raise ArgumentError, ~r/JWT secret must be at least 32/, fn ->
+        Bier.Config.new!([jwt_secret: "short_secret"], Bier.schema())
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/config_test.exs`
+Expected: FAIL — `function Bier.Config.validate_jwt_secret/1 is undefined`.
+
+- [ ] **Step 3: Implement the validators and wire them into `new!/2`**
+
+In `lib/bier/config.ex`, add the public validators and call them from `new!/2`. Replace the existing `new!/2` body so it runs the new checks alongside `validate_admin_server_port!/1`:
+
+```elixir
+  @spec new!(Keyword.t(), Keyword.t()) :: t() | no_return()
+  def new!(opts, schema) do
+    conf = NimbleOptions.validate!(opts, schema)
+
+    validate_admin_server_port!(conf)
+    raise_if_error!(validate_jwt_secret(conf[:jwt_secret]))
+    raise_if_error!(validate_jwt_aud(conf[:jwt_aud]))
+
+    struct!(__MODULE__, conf)
+  end
+
+  @doc """
+  A symmetric (text) JWT secret must be at least 32 characters long. `nil`
+  (no secret configured) is allowed. Mirrors PostgREST conformance case 1708.
+  """
+  @spec validate_jwt_secret(String.t() | nil) :: :ok | {:error, String.t()}
+  def validate_jwt_secret(nil), do: :ok
+
+  def validate_jwt_secret(secret) when is_binary(secret) do
+    if String.length(secret) >= 32 do
+      :ok
+    else
+      {:error, "The JWT secret must be at least 32 characters long."}
+    end
+  end
+
+  @doc """
+  `jwt-aud` may be any plain string, but a value containing ':' must parse as a
+  valid absolute URI (scheme + host). Mirrors PostgREST conformance case 1709.
+  """
+  @spec validate_jwt_aud(String.t() | nil) :: :ok | {:error, String.t()}
+  def validate_jwt_aud(nil), do: :ok
+
+  def validate_jwt_aud(aud) when is_binary(aud) do
+    cond do
+      not String.contains?(aud, ":") ->
+        :ok
+
+      valid_uri?(aud) ->
+        :ok
+
+      true ->
+        {:error, "jwt-aud should be a string or a valid URI"}
+    end
+  end
+
+  defp valid_uri?(value) do
+    case URI.new(value) do
+      {:ok, %URI{scheme: scheme, host: host}}
+      when is_binary(scheme) and is_binary(host) and host != "" ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  defp raise_if_error!(:ok), do: :ok
+  defp raise_if_error!({:error, message}), do: raise(ArgumentError, message)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/config_test.exs`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/bier/config.ex test/bier/config_test.exs
+git commit -m "feat(#40): shared jwt-secret/jwt-aud validators in Bier.Config"
+```
+
+---
+
+## Task 2: Config-file parser `Bier.CLI.ConfigFile`
+
+Parses the PostgREST-compatible `key = value` subset into a `%{kebab_key => raw_value}` map. A missing file is fatal (case 1719).
+
+**Files:**
+- Create: `lib/bier/cli/config_file.ex`
+- Test: `test/bier/cli/config_file_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/bier/cli/config_file_test.exs`:
+
+```elixir
+defmodule Bier.CLI.ConfigFileTest do
+  use ExUnit.Case, async: true
+
+  alias Bier.CLI.ConfigFile
+
+  test "parses quoted strings, bare ints and bools, ignores comments/blanks" do
+    contents = """
+    # a comment
+    db-schemas = "api,public"
+
+    server-port = 3000
+    jwt-secret-is-base64 = true
+    """
+
+    assert ConfigFile.parse(contents) ==
+             {:ok,
+              %{
+                "db-schemas" => "api,public",
+                "server-port" => 3000,
+                "jwt-secret-is-base64" => true
+              }}
+  end
+
+  test "unquotes escaped quotes inside string values" do
+    assert ConfigFile.parse(~S(role-claim-key = ".\"role\"")) ==
+             {:ok, %{"role-claim-key" => ~S(."role")}}
+  end
+
+  test "read/1 errors on a missing file" do
+    assert {:error, message} = ConfigFile.read("does_not_exist.conf")
+    assert message =~ "does_not_exist.conf"
+  end
+
+  test "read/1 parses an existing file" do
+    path = Path.join(System.tmp_dir!(), "bier_cfg_#{System.unique_integer([:positive])}.conf")
+    File.write!(path, "log-level = \"info\"\n")
+    on_exit(fn -> File.rm(path) end)
+
+    assert ConfigFile.read(path) == {:ok, %{"log-level" => "info"}}
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/cli/config_file_test.exs`
+Expected: FAIL — `module Bier.CLI.ConfigFile is not available`.
+
+- [ ] **Step 3: Implement the parser**
+
+Create `lib/bier/cli/config_file.ex`:
+
+```elixir
+defmodule Bier.CLI.ConfigFile do
+  @moduledoc """
+  Parses the PostgREST-compatible config-file subset into a
+  `%{kebab_key => raw_value}` map: `key = value` lines, `#` comments, blank
+  lines, double-quoted strings (with `\\"` escapes), bare integers, and bare
+  `true`/`false`. Raw values are returned untyped; `Bier.CLI.Config` coerces
+  them per the target key.
+  """
+
+  @doc "Read and parse a config file. A missing file is a fatal error."
+  @spec read(Path.t()) :: {:ok, map()} | {:error, String.t()}
+  def read(path) do
+    case File.read(path) do
+      {:ok, contents} -> parse(contents)
+      {:error, reason} -> {:error, "could not read config file #{path}: #{:file.format_error(reason)}"}
+    end
+  end
+
+  @doc "Parse config-file contents."
+  @spec parse(String.t()) :: {:ok, map()} | {:error, String.t()}
+  def parse(contents) do
+    contents
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == "" or String.starts_with?(&1, "#")))
+    |> Enum.reduce_while({:ok, %{}}, fn line, {:ok, acc} ->
+      case parse_line(line) do
+        {:ok, {key, value}} -> {:cont, {:ok, Map.put(acc, key, value)}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp parse_line(line) do
+    case String.split(line, "=", parts: 2) do
+      [raw_key, raw_value] ->
+        {:ok, {String.trim(raw_key), parse_value(String.trim(raw_value))}}
+
+      _ ->
+        {:error, "malformed config line: #{inspect(line)}"}
+    end
+  end
+
+  defp parse_value(<<?", _::binary>> = quoted) do
+    quoted
+    |> String.trim("\"")
+    |> String.replace(~S(\"), ~S("))
+  end
+
+  defp parse_value("true"), do: true
+  defp parse_value("false"), do: false
+
+  defp parse_value(value) do
+    case Integer.parse(value) do
+      {int, ""} -> int
+      _ -> value
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/cli/config_file_test.exs`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/bier/cli/config_file.ex test/bier/cli/config_file_test.exs
+git commit -m "feat(#40): Bier.CLI.ConfigFile key=value parser"
+```
+
+---
+
+## Task 3: Mapping table + coercion in `Bier.CLI.Config`
+
+Defines the single source of truth: which PostgREST keys Bier implements, their `PGRST_*` env names, aliases, types, and PostgREST defaults — plus the per-type coercion that turns raw strings into typed values and produces PostgREST-exact enum error messages (cases 1710/1712/1713).
+
+**Files:**
+- Create: `lib/bier/cli/config.ex`
+- Test: `test/bier/cli/config_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/bier/cli/config_test.exs`:
+
+```elixir
+defmodule Bier.CLI.ConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Bier.CLI.Config
+
+  describe "coerce/2" do
+    test ":csv splits on commas" do
+      assert Config.coerce(:csv, "multi,tenant,setup") == {:ok, ["multi", "tenant", "setup"]}
+    end
+
+    test ":csv_emptyable yields [] for empty string" do
+      assert Config.coerce(:csv_emptyable, "") == {:ok, []}
+    end
+
+    test ":opt_int parses ints, treats wrong type as absent" do
+      assert Config.coerce(:opt_int, "1000") == {:ok, 1000}
+      assert Config.coerce(:opt_int, true) == {:ok, :unset}
+      assert Config.coerce(:opt_int, "") == {:ok, :unset}
+    end
+
+    test ":opt_string treats empty string as absent" do
+      assert Config.coerce(:opt_string, "") == {:ok, :unset}
+      assert Config.coerce(:opt_string, "x") == {:ok, "x"}
+    end
+
+    test "log-level enum maps known values, rejects unknown with PostgREST message" do
+      assert Config.coerce({:enum_atom, :log_level}, "info") == {:ok, :info}
+
+      assert Config.coerce({:enum_atom, :log_level}, "never") ==
+               {:error, "Invalid logging level. Check your configuration."}
+    end
+
+    test "db-tx-end enum rejects unknown with PostgREST message" do
+      assert Config.coerce({:enum_atom, :db_tx_end}, "commit-allow-override") ==
+               {:ok, :"commit-allow-override"}
+
+      assert Config.coerce({:enum_atom, :db_tx_end}, "random") ==
+               {:error, "Invalid transaction termination. Check your configuration."}
+    end
+
+    test "openapi-mode enum stays a string, rejects unknown with PostgREST message" do
+      assert Config.coerce({:enum_str, :openapi_mode}, "ignore-privileges") ==
+               {:ok, "ignore-privileges"}
+
+      assert Config.coerce({:enum_str, :openapi_mode}, "follow-") ==
+               {:error, "Invalid openapi-mode. Check your configuration."}
+    end
+  end
+
+  describe "spec/0" do
+    test "exposes db-schemas with its alias and env var" do
+      entry = Enum.find(Config.spec(), &(&1.key == "db-schemas"))
+      assert entry.env == "PGRST_DB_SCHEMAS"
+      assert "db-schema" in entry.aliases
+      assert entry.kind == :csv
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/cli/config_test.exs`
+Expected: FAIL — `module Bier.CLI.Config is not available`.
+
+- [ ] **Step 3: Implement the spec table and coercion**
+
+Create `lib/bier/cli/config.ex`:
+
+```elixir
+defmodule Bier.CLI.Config do
+  @moduledoc """
+  The PostgREST config dialect ↔ Bier boundary.
+
+  `spec/0` is the single source of truth: one entry per PostgREST config key
+  that Bier implements, carrying its `PGRST_*` env var, deprecated aliases,
+  value type, and PostgREST default (used for `--dump-config`). Keys Bier does
+  not implement are intentionally absent — their conformance cases stay
+  deferred.
+  """
+
+  alias Bier.CLI.ConfigFile
+
+  # kind:
+  #   :string | :opt_string | :int | :opt_int | :bool
+  #   :csv | :csv_emptyable
+  #   {:enum_atom, name} | {:enum_str, name}
+  # default: the PostgREST default, rendered by dump/1 when unset.
+  @spec [
+    %{key: "db-uri", env: "PGRST_DB_URI", kind: :string, default: "postgresql://", aliases: []},
+    %{key: "db-schemas", env: "PGRST_DB_SCHEMAS", kind: :csv, default: ["public"], aliases: ["db-schema"]},
+    %{key: "db-anon-role", env: "PGRST_DB_ANON_ROLE", kind: :opt_string, default: :unset, aliases: []},
+    %{key: "db-extra-search-path", env: "PGRST_DB_EXTRA_SEARCH_PATH", kind: :csv_emptyable, default: ["public"], aliases: []},
+    %{key: "db-max-rows", env: "PGRST_DB_MAX_ROWS", kind: :opt_int, default: :unset, aliases: ["max-rows"]},
+    %{key: "db-tx-end", env: "PGRST_DB_TX_END", kind: {:enum_atom, :db_tx_end}, default: :commit, aliases: []},
+    %{key: "db-pre-request", env: "PGRST_DB_PRE_REQUEST", kind: :opt_string, default: :unset, aliases: ["pre-request"]},
+    %{key: "db-root-spec", env: "PGRST_DB_ROOT_SPEC", kind: :opt_string, default: :unset, aliases: ["root-spec"]},
+    %{key: "server-port", env: "PGRST_SERVER_PORT", kind: :int, default: 3000, aliases: []},
+    %{key: "admin-server-port", env: "PGRST_ADMIN_SERVER_PORT", kind: :opt_int, default: :unset, aliases: []},
+    %{key: "jwt-secret", env: "PGRST_JWT_SECRET", kind: :opt_string, default: :unset, aliases: []},
+    %{key: "jwt-aud", env: "PGRST_JWT_AUD", kind: :opt_string, default: :unset, aliases: []},
+    %{key: "openapi-mode", env: "PGRST_OPENAPI_MODE", kind: {:enum_str, :openapi_mode}, default: "follow-privileges", aliases: []},
+    %{key: "log-level", env: "PGRST_LOG_LEVEL", kind: {:enum_atom, :log_level}, default: :error, aliases: []},
+    %{key: "server-cors-allowed-origins", env: "PGRST_SERVER_CORS_ALLOWED_ORIGINS", kind: :opt_string, default: :unset, aliases: []}
+  ]
+
+  @enum_atoms %{
+    log_level: %{
+      values: %{"crit" => :crit, "error" => :error, "warn" => :warn, "info" => :info, "debug" => :debug},
+      message: "Invalid logging level. Check your configuration."
+    },
+    db_tx_end: %{
+      values: %{
+        "commit" => :commit,
+        "commit-allow-override" => :"commit-allow-override",
+        "rollback" => :rollback,
+        "rollback-allow-override" => :"rollback-allow-override"
+      },
+      message: "Invalid transaction termination. Check your configuration."
+    }
+  }
+
+  @enum_strs %{
+    openapi_mode: %{
+      values: ["follow-privileges", "ignore-privileges", "disabled"],
+      message: "Invalid openapi-mode. Check your configuration."
+    }
+  }
+
+  @doc "The config key spec table (one entry per implemented PostgREST key)."
+  @spec spec() :: [map()]
+  def spec, do: @spec
+
+  @doc """
+  Coerce a raw value (string from env/file, or already-typed from the file
+  parser) to the typed value for `kind`. `:unset` marks an absent optional
+  value (falls back to default). Enum mismatches return PostgREST's message.
+  """
+  @spec coerce(term(), term()) :: {:ok, term()} | {:error, String.t()}
+  def coerce(:string, v), do: {:ok, to_string(v)}
+
+  def coerce(:opt_string, v) do
+    case to_string(v) do
+      "" -> {:ok, :unset}
+      s -> {:ok, s}
+    end
+  end
+
+  def coerce(:int, v) do
+    case parse_int(v) do
+      {:ok, int} -> {:ok, int}
+      :error -> {:ok, :unset}
+    end
+  end
+
+  def coerce(:opt_int, v) do
+    case parse_int(v) do
+      {:ok, int} -> {:ok, int}
+      :error -> {:ok, :unset}
+    end
+  end
+
+  def coerce(:bool, v), do: {:ok, v in [true, "true", "1", 1]}
+
+  def coerce(:csv, v), do: {:ok, split_csv(to_string(v))}
+
+  def coerce(:csv_emptyable, v) do
+    case to_string(v) do
+      "" -> {:ok, []}
+      s -> {:ok, split_csv(s)}
+    end
+  end
+
+  def coerce({:enum_atom, name}, v) do
+    %{values: values, message: message} = Map.fetch!(@enum_atoms, name)
+
+    case Map.fetch(values, to_string(v)) do
+      {:ok, atom} -> {:ok, atom}
+      :error -> {:error, message}
+    end
+  end
+
+  def coerce({:enum_str, name}, v) do
+    %{values: values, message: message} = Map.fetch!(@enum_strs, name)
+    s = to_string(v)
+    if s in values, do: {:ok, s}, else: {:error, message}
+  end
+
+  defp parse_int(v) when is_integer(v), do: {:ok, v}
+
+  defp parse_int(v) do
+    case Integer.parse(to_string(v)) do
+      {int, ""} -> {:ok, int}
+      _ -> :error
+    end
+  end
+
+  defp split_csv(s) do
+    s |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == ""))
+  end
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/cli/config_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/bier/cli/config.ex test/bier/cli/config_test.exs
+git commit -m "feat(#40): Bier.CLI.Config mapping table + value coercion"
+```
+
+---
+
+## Task 4: `Bier.CLI.Config.load/3` — sources, precedence, aliases, validation
+
+Resolves each spec key from `flags > PGRST_* env > config file > default`, applies aliases, coerces, and runs the shared semantic validators. Returns a resolved `%{kebab_key => typed_value}` map or `{:error, message}`.
+
+**Files:**
+- Modify: `lib/bier/cli/config.ex`
+- Test: `test/bier/cli/config_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/bier/cli/config_test.exs` (inside the module):
+
+```elixir
+  describe "load/3" do
+    test "reads from environment only" do
+      env = %{"PGRST_DB_SCHEMAS" => "multi,tenant,setup", "PGRST_DB_MAX_ROWS" => "1000", "PGRST_LOG_LEVEL" => "info"}
+      assert {:ok, resolved} = Config.load(env, nil, [])
+      assert resolved["db-schemas"] == ["multi", "tenant", "setup"]
+      assert resolved["db-max-rows"] == 1000
+      assert resolved["log-level"] == :info
+    end
+
+    test "env overrides file (case 1720)" do
+      file = %{"db-max-rows" => 100, "log-level" => "warn"}
+      env = %{"PGRST_DB_MAX_ROWS" => "999", "PGRST_LOG_LEVEL" => "debug"}
+      assert {:ok, resolved} = Config.load(env, file, [])
+      assert resolved["db-max-rows"] == 999
+      assert resolved["log-level"] == :debug
+    end
+
+    test "resolves the db-schema alias (case 1730)" do
+      assert {:ok, resolved} = Config.load(%{}, %{"db-schema" => "aliased_schema"}, [])
+      assert resolved["db-schemas"] == ["aliased_schema"]
+    end
+
+    test "wrong type for an int key falls back to default/unset (case 1721)" do
+      assert {:ok, resolved} = Config.load(%{}, %{"db-max-rows" => true}, [])
+      assert resolved["db-max-rows"] == :unset
+    end
+
+    test "empty log-level falls back to default error (case 1723)" do
+      assert {:ok, resolved} = Config.load(%{"PGRST_LOG_LEVEL" => ""}, nil, [])
+      assert resolved["log-level"] == :error
+    end
+
+    test "a too-short jwt-secret is fatal (case 1708)" do
+      assert Config.load(%{"PGRST_JWT_SECRET" => "short_secret"}, nil, []) ==
+               {:error, "The JWT secret must be at least 32 characters long."}
+    end
+
+    test "an unknown log-level is fatal (case 1712)" do
+      assert Config.load(%{"PGRST_LOG_LEVEL" => "never"}, nil, []) ==
+               {:error, "Invalid logging level. Check your configuration."}
+    end
+  end
+```
+
+Note: an empty `PGRST_LOG_LEVEL` (case 1723) is an empty optional string → absent → the key's default (`:error`); coercion of an *unset* source is skipped (see implementation). The enum coercion only runs on a present, non-empty value.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/cli/config_test.exs`
+Expected: FAIL — `function Bier.CLI.Config.load/3 is undefined`.
+
+- [ ] **Step 3: Implement `load/3`**
+
+Add to `lib/bier/cli/config.ex`. The resolver treats an empty string / missing source as "absent" *before* coercion, so an empty value falls back to the default rather than hitting enum validation:
+
+```elixir
+  @doc """
+  Resolve every spec key from flags > env > file > default, applying aliases and
+  coercion, then run the shared semantic validators. Returns the resolved
+  `%{kebab_key => typed_value}` map, or `{:error, message}` on a fatal problem.
+
+  `env` is a `%{"PGRST_*" => string}` map (the caller supplies it — the core
+  never reads `System.get_env/0`). `file` is `nil` or a `%{kebab_key => raw}`
+  map (from `Bier.CLI.ConfigFile`). `flags` is a `%{kebab_key => raw}` map of
+  command-line overrides.
+  """
+  @spec load(map(), map() | nil, map()) :: {:ok, map()} | {:error, String.t()}
+  def load(env, file, flags) do
+    file = file || %{}
+
+    Enum.reduce_while(@spec, {:ok, %{}}, fn entry, {:ok, acc} ->
+      case resolve(entry, env, file, flags) do
+        {:ok, value} -> {:cont, {:ok, Map.put(acc, entry.key, value)}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+    |> validate()
+  end
+
+  defp resolve(entry, env, file, flags) do
+    case raw_source(entry, env, file, flags) do
+      :absent -> {:ok, entry.default}
+      {:present, raw} -> coerce(entry.kind, raw)
+    end
+  end
+
+  # Precedence: flags > env > file. Aliases are consulted for file keys only
+  # (PostgREST aliases are file/env spellings; flags use canonical keys).
+  defp raw_source(entry, env, file, flags) do
+    cond do
+      present?(Map.get(flags, entry.key)) -> {:present, Map.fetch!(flags, entry.key)}
+      present?(Map.get(env, entry.env)) -> {:present, Map.fetch!(env, entry.env)}
+      true -> file_source(entry, file)
+    end
+  end
+
+  defp file_source(entry, file) do
+    keys = [entry.key | entry.aliases]
+
+    case Enum.find(keys, fn k -> present?(Map.get(file, k)) end) do
+      nil -> :absent
+      key -> {:present, Map.fetch!(file, key)}
+    end
+  end
+
+  # An empty string is "absent" so it falls back to the key's default; nil/missing
+  # is absent; any other value (including 0/false/integers) is present.
+  defp present?(nil), do: false
+  defp present?(""), do: false
+  defp present?(_), do: true
+
+  defp validate({:error, _} = err), do: err
+
+  defp validate({:ok, resolved}) do
+    with :ok <- run_validator(resolved, "jwt-secret", &Bier.Config.validate_jwt_secret/1),
+         :ok <- run_validator(resolved, "jwt-aud", &Bier.Config.validate_jwt_aud/1),
+         :ok <- validate_admin_port(resolved) do
+      {:ok, resolved}
+    end
+  end
+
+  defp run_validator(resolved, key, fun) do
+    case Map.get(resolved, key) do
+      :unset -> :ok
+      value -> fun.(value)
+    end
+  end
+
+  # admin-server-port must differ from server-port (case 1717). server-port has a
+  # default, so it is always present; admin-server-port may be :unset.
+  defp validate_admin_port(resolved) do
+    case {Map.get(resolved, "admin-server-port"), Map.get(resolved, "server-port")} do
+      {port, port} when is_integer(port) -> {:error, "admin-server-port cannot be the same as server-port"}
+      _ -> :ok
+    end
+  end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/cli/config_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/bier/cli/config.ex test/bier/cli/config_test.exs
+git commit -m "feat(#40): Bier.CLI.Config.load/3 precedence, aliases, validation"
+```
+
+---
+
+## Task 5: `Bier.CLI.Config.dump/1` — PostgREST-format serialization
+
+Renders a resolved config map to PostgREST `--dump-config` text: one sorted `key = value` line per spec key. Strings quoted, ints bare, lists comma-joined+quoted, `:unset`/atoms rendered PostgREST-style. Deterministic ⇒ reparse-stable (case 1726).
+
+**Files:**
+- Modify: `lib/bier/cli/config.ex`
+- Test: `test/bier/cli/config_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/bier/cli/config_test.exs`:
+
+```elixir
+  describe "dump/1" do
+    test "renders strings, ints, lists, atoms and unset values PostgREST-style" do
+      {:ok, resolved} =
+        Config.load(%{"PGRST_DB_SCHEMAS" => "multi,tenant,setup", "PGRST_DB_MAX_ROWS" => "1000", "PGRST_LOG_LEVEL" => "info"}, nil, [])
+
+      dump = Config.dump(resolved) |> IO.iodata_to_binary()
+
+      assert dump =~ ~s(db-schemas = "multi,tenant,setup")
+      assert dump =~ ~s(db-max-rows = 1000)
+      assert dump =~ ~s(log-level = "info")
+      # unset optional renders as empty string
+      assert dump =~ ~s(db-anon-role = "")
+      assert dump =~ ~s(db-max-rows = 1000)
+    end
+
+    test "an unset db-max-rows renders as empty string (case 1721)" do
+      {:ok, resolved} = Config.load(%{}, %{"db-max-rows" => true}, [])
+      dump = Config.dump(resolved) |> IO.iodata_to_binary()
+      assert dump =~ ~s(db-max-rows = "")
+    end
+
+    test "db-tx-end round-trips its value (case 1722)" do
+      {:ok, resolved} = Config.load(%{"PGRST_DB_TX_END" => "commit-allow-override"}, nil, [])
+      dump = Config.dump(resolved) |> IO.iodata_to_binary()
+      assert dump =~ ~s(db-tx-end = "commit-allow-override")
+    end
+
+    test "db-extra-search-path renders empty list as empty string (case 1728)" do
+      {:ok, resolved} = Config.load(%{"PGRST_DB_EXTRA_SEARCH_PATH" => ""}, nil, [])
+      dump = Config.dump(resolved) |> IO.iodata_to_binary()
+      assert dump =~ ~s(db-extra-search-path = "")
+    end
+
+    test "dump output is reparse-stable" do
+      {:ok, resolved} = Config.load(%{"PGRST_DB_MAX_ROWS" => "1000", "PGRST_SERVER_PORT" => "80", "PGRST_LOG_LEVEL" => "info"}, nil, [])
+      dump1 = Config.dump(resolved) |> IO.iodata_to_binary()
+
+      {:ok, file} = Bier.CLI.ConfigFile.parse(dump1)
+      {:ok, resolved2} = Config.load(%{}, file, [])
+      dump2 = Config.dump(resolved2) |> IO.iodata_to_binary()
+
+      assert dump1 == dump2
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/cli/config_test.exs`
+Expected: FAIL — `function Bier.CLI.Config.dump/1 is undefined`.
+
+- [ ] **Step 3: Implement `dump/1`**
+
+Add to `lib/bier/cli/config.ex`:
+
+```elixir
+  @doc """
+  Render a resolved config map as PostgREST `--dump-config` text: one
+  `key = value` line per spec key, sorted by key for determinism (so the output
+  is reparse-stable).
+  """
+  @spec dump(map()) :: iodata()
+  def dump(resolved) do
+    @spec
+    |> Enum.map(& &1.key)
+    |> Enum.sort()
+    |> Enum.map(fn key -> [key, " = ", render(Map.fetch!(resolved, key)), "\n"] end)
+  end
+
+  defp render(:unset), do: ~s("")
+  defp render(value) when is_integer(value), do: Integer.to_string(value)
+  defp render(true), do: "true"
+  defp render(false), do: "false"
+  defp render(value) when is_list(value), do: quote_string(Enum.join(value, ","))
+  defp render(value) when is_atom(value), do: quote_string(Atom.to_string(value))
+  defp render(value) when is_binary(value), do: quote_string(value)
+
+  defp quote_string(s), do: [?", String.replace(s, ~S("), ~S(\")), ?"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/cli/config_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/bier/cli/config.ex test/bier/cli/config_test.exs
+git commit -m "feat(#40): Bier.CLI.Config.dump/1 PostgREST-format output"
+```
+
+---
+
+## Task 6: `Bier.CLI.run/2` — argument parsing and dispatch
+
+The pure core. Parses argv into `{command, flags, file_path}`, calls `Config.load/3`, and returns `%{stdout, stderr, exit}` for terminal commands (`--dump-config`, `--version`, `--help`, validation errors, missing file). The default (no flag) command returns `{:boot, resolved}` for the escript to act on.
+
+**Files:**
+- Create: `lib/bier/cli.ex`
+- Test: `test/bier/cli_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/bier/cli_test.exs`:
+
+```elixir
+defmodule Bier.CLITest do
+  use ExUnit.Case, async: true
+
+  alias Bier.CLI
+
+  test "--dump-config prints config and exits 0" do
+    result = CLI.run(["--dump-config"], env: %{"PGRST_LOG_LEVEL" => "info"})
+    assert result.exit == 0
+    assert IO.iodata_to_binary(result.stdout) =~ ~s(log-level = "info")
+    assert IO.iodata_to_binary(result.stderr) == ""
+  end
+
+  test "--dump-config with an invalid value prints the message to stderr, nonzero exit" do
+    result = CLI.run(["--dump-config"], env: %{"PGRST_JWT_SECRET" => "short_secret"})
+    assert result.exit != 0
+    assert IO.iodata_to_binary(result.stderr) =~ "The JWT secret must be at least 32 characters long."
+    assert IO.iodata_to_binary(result.stdout) == ""
+  end
+
+  test "a missing config file is fatal" do
+    result = CLI.run(["does_not_exist.conf", "--dump-config"], env: %{})
+    assert result.exit != 0
+    assert IO.iodata_to_binary(result.stderr) =~ "does_not_exist.conf"
+  end
+
+  test "--version prints the version and exits 0" do
+    result = CLI.run(["--version"], env: %{})
+    assert result.exit == 0
+    assert IO.iodata_to_binary(result.stdout) =~ "bier"
+  end
+
+  test "--help prints usage and exits 0" do
+    result = CLI.run(["--help"], env: %{})
+    assert result.exit == 0
+    assert IO.iodata_to_binary(result.stdout) =~ "Usage"
+  end
+
+  test "no flag returns a boot directive" do
+    assert {:boot, resolved} = CLI.run([], env: %{"PGRST_LOG_LEVEL" => "info"})
+    assert resolved["log-level"] == :info
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/cli_test.exs`
+Expected: FAIL — `module Bier.CLI is not available`.
+
+- [ ] **Step 3: Implement `run/2`**
+
+Create `lib/bier/cli.ex`:
+
+```elixir
+defmodule Bier.CLI do
+  @moduledoc """
+  Command-line interface for running Bier as a standalone, drop-in
+  PostgREST-compatible service.
+
+  `run/2` is the pure core: it takes argv plus an explicit environment and
+  returns `%{stdout, stderr, exit}` for terminal commands, or `{:boot,
+  resolved}` for the default run-the-server action. It performs no IO and never
+  halts — the conformance suite drives it directly. `main/1` is the escript
+  wrapper that supplies real IO and `System.halt/1`.
+  """
+
+  alias Bier.CLI.{Config, ConfigFile}
+
+  @type result :: %{stdout: iodata(), stderr: iodata(), exit: non_neg_integer()}
+
+  @doc "Run the CLI core. `opts[:env]` is a `%{\"PGRST_*\" => string}` map."
+  @spec run([String.t()], keyword()) :: result() | {:boot, map()}
+  def run(argv, opts \\ []) do
+    env = Keyword.get(opts, :env, %{})
+    {command, file_path} = parse_argv(argv)
+
+    with {:ok, file} <- read_file(file_path),
+         {:ok, resolved} <- Config.load(env, file, %{}) do
+      dispatch(command, resolved)
+    else
+      {:error, message} -> error(message)
+    end
+  end
+
+  defp dispatch(:version, _resolved), do: ok(version_line())
+  defp dispatch(:help, _resolved), do: ok(usage())
+  defp dispatch(:dump_config, resolved), do: ok(Config.dump(resolved))
+  defp dispatch(:run, resolved), do: {:boot, resolved}
+
+  # The optional positional config-file path is any argv element not starting
+  # with "-". Recognized flags select the command; default command is :run.
+  defp parse_argv(argv) do
+    file_path = Enum.find(argv, fn arg -> not String.starts_with?(arg, "-") end)
+    command = Enum.find_value(argv, :run, &flag_command/1)
+    {command, file_path}
+  end
+
+  defp flag_command("--dump-config"), do: :dump_config
+  defp flag_command("--version"), do: :version
+  defp flag_command("-v"), do: :version
+  defp flag_command("--help"), do: :help
+  defp flag_command("-h"), do: :help
+  defp flag_command(_), do: nil
+
+  defp read_file(nil), do: {:ok, nil}
+  defp read_file(path), do: ConfigFile.read(path)
+
+  defp version_line do
+    vsn = Application.spec(:bier, :vsn) || ~c"unknown"
+    "bier #{vsn}\n"
+  end
+
+  defp usage do
+    """
+    Usage: bier [CONFIG_FILE] [OPTIONS]
+
+    Runs Bier as a standalone PostgREST-compatible REST server. Config is read
+    from PGRST_* environment variables, an optional CONFIG_FILE, and flags.
+
+    Options:
+      --dump-config   Print the loaded configuration and exit
+      -v, --version   Print the version and exit
+      -h, --help      Print this help and exit
+    """
+  end
+
+  defp ok(stdout), do: %{stdout: stdout, stderr: "", exit: 0}
+  defp error(message), do: %{stdout: "", stderr: [message, "\n"], exit: 1}
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/bier/cli_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/bier/cli.ex test/bier/cli_test.exs
+git commit -m "feat(#40): Bier.CLI.run/2 core dispatch"
+```
+
+---
+
+## Task 7: escript wrapper + `to_start_opts/1` + mix.exs
+
+Adds the thin escript entry point and the translation from a resolved config map to `Bier.start_link/1` keyword opts (used by the boot path). The boot path itself (start app, start one instance, block) is exercised by the release follow-up; here we unit-test the opts translation.
+
+**Files:**
+- Modify: `lib/bier/cli.ex`, `lib/bier/cli/config.ex`, `mix.exs`
+- Test: `test/bier/cli/config_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/bier/cli/config_test.exs`:
+
+```elixir
+  describe "to_start_opts/1" do
+    test "maps resolved keys to Bier.start_link/1 options" do
+      {:ok, resolved} =
+        Config.load(
+          %{
+            "PGRST_DB_URI" => "postgresql://alice:secret@db.example.com:5433/shop",
+            "PGRST_DB_SCHEMAS" => "api,public",
+            "PGRST_SERVER_PORT" => "4000",
+            "PGRST_LOG_LEVEL" => "info"
+          },
+          nil,
+          []
+        )
+
+      opts = Config.to_start_opts(resolved)
+
+      assert opts[:hostname] == "db.example.com"
+      assert opts[:port] == 5433
+      assert opts[:database] == "shop"
+      assert opts[:username] == "alice"
+      assert opts[:password] == "secret"
+      assert opts[:db_schemas] == ["api", "public"]
+      assert opts[:log_level] == :info
+      assert get_in(opts, [:router, :port]) == 4000
+    end
+
+    test "omits unset optional keys so Bier defaults apply" do
+      {:ok, resolved} = Config.load(%{}, nil, [])
+      opts = Config.to_start_opts(resolved)
+      refute Keyword.has_key?(opts, :db_max_rows)
+      refute Keyword.has_key?(opts, :jwt_secret)
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/bier/cli/config_test.exs`
+Expected: FAIL — `function Bier.CLI.Config.to_start_opts/1 is undefined`.
+
+- [ ] **Step 3: Implement `to_start_opts/1`**
+
+Add to `lib/bier/cli/config.ex`:
+
+```elixir
+  @doc """
+  Translate a resolved config map into a keyword list for `Bier.start_link/1`.
+  `:unset` optional keys are omitted so Bier's own defaults apply. `db-uri` is
+  parsed into discrete connection fields; `server-port` maps to `router[:port]`.
+  """
+  @spec to_start_opts(map()) :: keyword()
+  def to_start_opts(resolved) do
+    direct =
+      [
+        db_schemas: resolved["db-schemas"],
+        db_anon_role: resolved["db-anon-role"],
+        db_extra_search_path: resolved["db-extra-search-path"],
+        db_max_rows: resolved["db-max-rows"],
+        db_tx_end: resolved["db-tx-end"],
+        db_pre_request: resolved["db-pre-request"],
+        db_root_spec: resolved["db-root-spec"],
+        admin_server_port: resolved["admin-server-port"],
+        jwt_secret: resolved["jwt-secret"],
+        jwt_aud: resolved["jwt-aud"],
+        openapi_mode: resolved["openapi-mode"],
+        log_level: resolved["log-level"],
+        server_cors_allowed_origins: resolved["server-cors-allowed-origins"]
+      ]
+      |> Enum.reject(fn {_k, v} -> v == :unset end)
+
+    router = [port: resolved["server-port"], scheme: :http]
+
+    direct ++ [router: router] ++ db_uri_opts(resolved["db-uri"])
+  end
+
+  # Parse a libpq URI into Bier's discrete connection fields. An empty
+  # "postgresql://" carries no fields, so Bier's defaults apply.
+  defp db_uri_opts(uri) when uri in [nil, "", "postgresql://", "postgres://"], do: []
+
+  defp db_uri_opts(uri) do
+    %URI{host: host, port: port, path: path, userinfo: userinfo} = URI.parse(uri)
+    {user, pass} = split_userinfo(userinfo)
+    database = path |> to_string() |> String.trim_leading("/")
+
+    [
+      hostname: host,
+      port: port,
+      database: database,
+      username: user,
+      password: pass
+    ]
+    |> Enum.reject(fn {_k, v} -> v in [nil, ""] end)
+  end
+
+  defp split_userinfo(nil), do: {nil, nil}
+
+  defp split_userinfo(userinfo) do
+    case String.split(userinfo, ":", parts: 2) do
+      [user, pass] -> {user, pass}
+      [user] -> {user, nil}
+    end
+  end
+```
+
+- [ ] **Step 4: Run the opts test to verify it passes**
+
+Run: `mix test test/bier/cli/config_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Add the escript `main/1` and the boot path**
+
+Add to `lib/bier/cli.ex`:
+
+```elixir
+  @doc """
+  escript entry point. Supplies the real process environment, writes the
+  command's output to stdout/stderr, and halts with its exit code. For the
+  default run action it boots one standalone Bier instance and blocks.
+  """
+  @spec main([String.t()]) :: no_return()
+  def main(argv) do
+    case run(argv, env: System.get_env()) do
+      {:boot, resolved} -> boot(resolved)
+      %{stdout: out, stderr: err, exit: code} -> emit(out, err, code)
+    end
+  end
+
+  defp emit(out, err, code) do
+    IO.write(out)
+    IO.write(:stderr, err)
+    System.halt(code)
+  end
+
+  defp boot(resolved) do
+    {:ok, _} = Application.ensure_all_started(:bier)
+    {:ok, _pid} = Bier.start_link(Bier.CLI.Config.to_start_opts(resolved))
+    Process.sleep(:infinity)
+  end
+```
+
+- [ ] **Step 6: Configure the escript in mix.exs**
+
+In `mix.exs`, add `escript: escript()` to the `project/0` keyword list (next to `aliases: aliases()`), and add the private function. `app: nil` prevents auto-starting the app, so `--dump-config` runs without a DB:
+
+```elixir
+  defp escript do
+    [main_module: Bier.CLI, app: nil]
+  end
+```
+
+- [ ] **Step 7: Verify the escript builds and runs**
+
+Run: `mix escript.build && PGRST_LOG_LEVEL=info ./bier --dump-config`
+Expected: prints the config including `log-level = "info"`, exits 0. Then:
+Run: `./bier --version`
+Expected: prints `bier <version>`, exits 0.
+Run: `rm -f bier` (don't commit the built artifact; confirm it's git-ignored or remove it).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/bier/cli.ex lib/bier/cli/config.ex mix.exs test/bier/cli/config_test.exs
+git commit -m "feat(#40): escript entry point + to_start_opts + boot path"
+```
+
+---
+
+## Task 8: Conformance harness — CLI case path
+
+Wires `kind: cli` cases through `Bier.CLI.run/2`: a `Bier.CliCase` template, the new assertions, and a test dispatch that defers only the explicitly-listed IDs.
+
+**Files:**
+- Create: `test/support/cli_case.ex`
+- Modify: `test/support/conformance_assertions.ex`, `test/conformance/conformance_test.exs`
+
+- [ ] **Step 1: Implement the CLI case template**
+
+Create `test/support/cli_case.ex`:
+
+```elixir
+defmodule Bier.CliCase do
+  @moduledoc """
+  Drives a `kind: cli` conformance case through `Bier.CLI.run/2` in-process and
+  returns a normalized `%{stdout, stderr, exit}` map (iodata flattened to
+  strings). Any `config.file` map is written to a temp file; `config.env`
+  becomes the env map passed to the core.
+  """
+
+  @doc "Run a CLI conformance case and return its normalized result."
+  def perform(%Bier.ConformanceCase{request: req, config: config}) do
+    env = Map.get(config, "env", %{})
+    file_path = write_config_file(Map.get(config, "file"))
+    argv = build_argv(Map.get(req, "flag"), file_path)
+
+    try do
+      result = Bier.CLI.run(argv, env: env)
+
+      %{
+        stdout: IO.iodata_to_binary(result.stdout),
+        stderr: IO.iodata_to_binary(result.stderr),
+        exit: result.exit
+      }
+    after
+      if file_path, do: File.rm(file_path)
+    end
+  end
+
+  # The case `flag` is either a CLI flag ("--dump-config") or a config-file
+  # path that does not exist ("does_not_exist.conf", case 1719).
+  defp build_argv(nil, file_path), do: List.wrap(file_path)
+  defp build_argv("--" <> _ = flag, file_path), do: List.wrap(file_path) ++ [flag]
+  defp build_argv(path, _file_path), do: [path]
+
+  defp write_config_file(nil), do: nil
+
+  defp write_config_file(file_map) do
+    path = Path.join(System.tmp_dir!(), "bier_conf_#{System.unique_integer([:positive])}.conf")
+    File.write!(path, render_file(file_map))
+    path
+  end
+
+  defp render_file(file_map) do
+    Enum.map_join(file_map, "\n", fn {k, v} -> "#{k} = #{render_value(v)}" end) <> "\n"
+  end
+
+  defp render_value(v) when is_binary(v), do: ~s("#{v}")
+  defp render_value(v) when is_boolean(v), do: to_string(v)
+  defp render_value(v) when is_integer(v), do: Integer.to_string(v)
+end
+```
+
+- [ ] **Step 2: Add the CLI assertions**
+
+In `test/support/conformance_assertions.ex`, add these `check/3` clauses **before** the catch-all `defp check(key, _val, _resp)` clause:
+
+```elixir
+  defp check("exit_code", "nonzero", resp) do
+    assert resp.exit != 0, "expected nonzero exit, got #{resp.exit}\nstderr: #{resp.stderr}"
+  end
+
+  defp check("exit_code", expected, resp) do
+    assert resp.exit == expected,
+           "expected exit #{expected}, got #{resp.exit}\nstderr: #{resp.stderr}"
+  end
+
+  defp check("dump_contains", needles, resp) when is_list(needles) do
+    Enum.each(needles, fn needle ->
+      assert String.contains?(resp.stdout, needle),
+             "dump did not contain #{inspect(needle)}\nfull dump:\n#{resp.stdout}"
+    end)
+  end
+
+  defp check("stderr_contains", needle, resp) when is_binary(needle) do
+    assert String.contains?(resp.stderr, needle),
+           "stderr did not contain #{inspect(needle)}\nfull stderr:\n#{resp.stderr}"
+  end
+
+  defp check("dump_reparse_stable", true, resp) do
+    path = Path.join(System.tmp_dir!(), "bier_reparse_#{System.unique_integer([:positive])}.conf")
+    File.write!(path, resp.stdout)
+
+    try do
+      second = Bier.CLI.run(["--dump-config", path], env: %{})
+
+      assert IO.iodata_to_binary(second.stdout) == resp.stdout,
+             "re-dumping the dumped config was not byte-identical"
+    after
+      File.rm(path)
+    end
+  end
+```
+
+- [ ] **Step 3: Dispatch CLI cases in the conformance test**
+
+In `test/conformance/conformance_test.exs`, add a module attribute listing the deferred IDs and their reason, and replace the `pending_reason` cond's `c.kind == :cli -> :cli` arm with a lookup. Then add an `else`-branch test body that runs the CLI path for non-deferred CLI cases.
+
+Replace the `pending_reason =` cond block with:
+
+```elixir
+    pending_reason =
+      cond do
+        c.kind == :cli -> cli_pending_reason(c.id)
+        Map.has_key?(c.request, "jwt") -> :jwt
+        Map.has_key?(c.expect, "body_jsonpath") -> :jsonpath
+        Map.has_key?(c.expect, "status_text") -> :status_text
+        true -> nil
+      end
+```
+
+Add near the top of the module (after `@moduletag :conformance`):
+
+```elixir
+  # CLI cases that map onto config Bier does not (yet) implement keep an honest
+  # pending reason instead of a façade. See
+  # docs/superpowers/specs/2026-06-07-cli-implementation-design.md.
+  @cli_deferred %{
+    1705 => :cli_parity,   # full default-table dump
+    1727 => :cli_parity,   # --example template
+    1707 => :unmodeled_key,
+    1711 => :unmodeled_key,
+    1714 => :unmodeled_key,
+    1715 => :unmodeled_key,
+    1716 => :unmodeled_key,
+    1718 => :unmodeled_key,
+    1729 => :unmodeled_key,
+    1724 => :db_config,
+    1725 => :db_config
+  }
+
+  defp cli_pending_reason(id), do: Map.get(@cli_deferred, id)
+```
+
+Change the runnable `test` body so CLI cases use the CLI path. Replace the existing `else` block's single `test` with a kind-aware version:
+
+```elixir
+    else
+      test "#{c.id} #{c.feature}" do
+        case_data = unquote(Macro.escape(c))
+
+        resp =
+          case case_data.kind do
+            :cli -> Bier.CliCase.perform(case_data)
+            :http -> perform(case_data)
+          end
+
+        assert_expect(resp, case_data.expect)
+      end
+    end
+```
+
+- [ ] **Step 4: Run the CLI conformance cases**
+
+Run: `mix test test/conformance/conformance_test.exs --only area:config`
+Expected: the non-deferred CLI cases (validation + dump for implemented keys) PASS; deferred ones are skipped as `:pending`. Note any case that fails and reconcile against the disposition table in the design doc — adjust `@cli_deferred` (with an honest reason) only if a case genuinely depends on an unmodeled key; otherwise fix the implementation.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/support/cli_case.ex test/support/conformance_assertions.ex test/conformance/conformance_test.exs
+git commit -m "feat(#40): conformance CLI case path + assertions"
+```
+
+---
+
+## Task 9: Full verification + docs
+
+**Files:**
+- Modify: `spec/COVERAGE.md` (if it tracks pending reasons), `.gitignore` (if the `bier` escript artifact is not ignored)
+
+- [ ] **Step 1: Confirm the escript artifact is ignored**
+
+Run: `git check-ignore bier || echo "NOT IGNORED"`
+If it prints `NOT IGNORED`, add `/bier` to `.gitignore` and commit:
+
+```bash
+echo "/bier" >> .gitignore
+git add .gitignore
+git commit -m "chore(#40): ignore built escript artifact"
+```
+
+- [ ] **Step 2: Run the CI gate commands**
+
+Run each and confirm clean:
+
+```bash
+mix format --check-formatted
+mix compile --warnings-as-errors
+mix docs --warnings-as-errors
+mix test
+```
+
+Expected: all pass. CLI conformance cases that map onto implemented config are green; deferred cases report as pending with their reason.
+
+- [ ] **Step 3: Update coverage docs**
+
+If `spec/COVERAGE.md` enumerates pending reasons (it references the schema_cache deferral pattern), add the CLI dispositions: which `config` cases now pass and which remain pending as `:cli_parity` / `:unmodeled_key` / `:db_config`. Match the file's existing format.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spec/COVERAGE.md
+git commit -m "docs(#40): record CLI conformance dispositions in COVERAGE.md"
+```
+
+---
+
+## Self-Review (completed)
+
+**Spec coverage:** in-process core + escript (Tasks 6/7) ✓; PostgREST dialect mapping incl. db-uri/server-port (Tasks 3/7) ✓; sources & precedence flags>env>file>default (Task 4) ✓; config-file subset + missing-file fatal (Task 2) ✓; shared validators with exact messages (Tasks 1/3/4) ✓; `--dump-config` PostgREST format + reparse-stable (Task 5) ✓; conformance harness path + new assertions + honest deferral (Task 8) ✓; honest disposition list matches the design doc's table (Task 8 `@cli_deferred`) ✓. Deferred-by-design (`--ready`, `--example`, release/Docker, db-config, unmodeled keys) are documented in Scope notes, not silently dropped.
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code; every command shows expected output.
+
+**Type consistency:** `Bier.CLI.Config.coerce/2`, `load/3`, `dump/1`, `to_start_opts/1`, `spec/0`; `Bier.CLI.ConfigFile.parse/1`/`read/1`; `Bier.Config.validate_jwt_secret/1`/`validate_jwt_aud/1`; `Bier.CLI.run/2` returns `%{stdout, stderr, exit}` or `{:boot, resolved}` consistently across Tasks 6–8; `Bier.CliCase.perform/1` flattens iodata to strings so the assertions' `String.contains?/2` calls hold.

--- a/docs/superpowers/specs/2026-06-07-cli-implementation-design.md
+++ b/docs/superpowers/specs/2026-06-07-cli-implementation-design.md
@@ -1,0 +1,287 @@
+# Bier CLI — standalone-runnable, drop-in PostgREST-compatible config
+
+**Issue:** #40 ([conformance][lib] CLI implementation — 26 pending config cases)
+**Date:** 2026-06-07
+**Status:** Approved design (pending written-spec review)
+
+## Context
+
+26 conformance cases in the `config` area (`spec/conformance/cases/1705–1730`)
+carry `request.kind == "cli"` and are tagged `:pending` (reason `:cli`) in
+`test/conformance/conformance_test.exs` because Bier has no command-line
+interface. They exercise PostgREST's CLI/config surface: flag parsing, env/file
+loading, `--dump-config`/`--example` output, validation messages, and exit
+codes.
+
+PostgREST is a single standalone binary, so its CLI *is* the product's entry
+point and `--dump-config` is its config-introspection surface. Bier, by
+contrast, is an Elixir **library**: it is configured through `Bier.start_link/1`
+keyword options inside a host application's supervision tree (`Bier.Application`
+starts only `Bier.Registry`; the host starts instances). Bier has no standalone
+daemon today.
+
+### How PostgREST does it (v14.12, for reference)
+
+- **One config record, one serializer.** `readAppConfig` parses all sources into
+  a single `AppConfig`; `toText :: AppConfig -> Text` renders it back.
+  `--dump-config` is "parse → `toText` → exit 0", which is why it is stable and
+  reparseable. The running server, the dump, and `--example` all read the same
+  record.
+- **Three sources, precedence db-settings > env > file > default.**
+- **CLI surface:** default action boots the server (`Run CmdRun`); flags
+  `--dump-config`, `--dump-schema`, `--example`/`-e`, `--ready` (hits the admin
+  server's `/ready`), `-v/--version`, plus an optional positional config-file
+  path.
+- **File format:** the Haskell `configurator` library (`key = value`, quoted
+  strings, `app.settings.*` dotted keys, comments).
+- **Aliases / coercion / validation:** `optWithAlias` tries canonical then
+  deprecated key; wrong-typed values coerce to absent and fall back to default
+  (never crash); validations `fail` with exact message strings.
+
+The key insight: PostgREST's full key table is **not** technical debt because
+PostgREST *implements every key in it*. For Bier, "should we model key X"
+reduces to "does Bier implement feature X." This design follows the *same
+pattern* as PostgREST, scaled to Bier's smaller (growing) feature set.
+
+## Goals
+
+1. Make Bier **runnable as a standalone service** (`docker run bier`,
+   eventually) — the adoption lever PostgREST's distribution model proves out.
+   A single instance, configured entirely from outside an Elixir host app.
+2. Be a **config-level drop-in for PostgREST** for the keys Bier implements:
+   same `PGRST_*` env vars, same kebab key names, a compatible config-file
+   format, and a PostgREST-format `--dump-config`. This is the compatibility
+   contract that makes "swap PostgREST for Bier" credible.
+3. Provide a **testable, in-process CLI core** the conformance harness can drive
+   directly, so `kind: cli` cases run fast and `async`-safe.
+4. Turn green every conformance case that maps onto config Bier **actually
+   implements**; give every other case a **documented, honest** pending reason.
+
+## Non-goals (explicitly deferred)
+
+- **Reproducing PostgREST's full key table / golden dump files.** Keys Bier does
+  not implement are simply absent from the mapping. Cases 1705 (full defaults
+  dump) and 1727 (`--example` template) stay deferred until every key exists.
+- **DB-role-settings config source** (`db-config`, `ALTER ROLE ... SET pgrst.*`)
+  — cases 1724/1725. Needs a live connection at parse time; out of scope here.
+- **Unmodeled keys:** `jwt-role-claim-key` (1711), `server-unix-socket-mode`
+  (1714/1715), `openapi-server-proxy-uri` (1716), `jwt-secret-is-base64` (1718),
+  `app.settings.*` (1729). They become reachable only when/if Bier implements
+  those features.
+- **`mix release` config + Dockerfile.** Split into a tracked follow-up issue;
+  mechanical and independently reviewable. This issue delivers the core, the
+  escript, the standalone boot path, and the conformance wiring.
+- **`--dump-schema`.** Not required by any case; out of scope.
+
+## Architecture
+
+```
+                       argv + env(map) + optional file path
+                                     │
+                                     ▼
+                         ┌───────────────────────┐
+   conformance harness ─▶│   Bier.CLI.run/2      │◀─ escript Bier.CLI.main/1
+   (in-process, async)   │  (pure, no IO/halt)   │   (System.argv/get_env/halt)
+                         └───────────┬───────────┘
+                                     │ %{stdout, stderr, exit}
+                ┌────────────────────┼─────────────────────┐
+                ▼                    ▼                      ▼
+        Bier.CLI.Config      Bier.CLI.Config.dump     command dispatch
+        .load(env,file,argv)  (PostgREST toText)      (--help/-v/--ready/
+                │                                       --dump-config/run)
+                ▼
+   PostgREST dialect → Bier.Config atoms
+   (kebab keys, PGRST_* env, aliases, coercion)
+                │
+                ▼
+        Bier.Config.new!/2  ── shared validators (PostgREST-exact messages) ──┐
+                │                                                              │
+                ▼                            also enforced by                 │
+        Bier.start_link/1 (standalone: one instance) ◀────────────────────────┘
+```
+
+The boundary translates the **PostgREST dialect** into Bier's internal
+`Bier.Config` atoms, then hands off to the *existing* `Bier.start_link/1` path.
+Validation lives in the shared config path so the library and the CLI reject
+identically.
+
+### Components
+
+**`Bier.CLI` (new, `lib/bier/cli.ex`)** — the entry point and command dispatch.
+- `run(argv, opts) :: %{stdout: iodata, stderr: iodata, exit: non_neg_integer}`
+  — pure core. `opts` supplies `:env` (a map, default `System.get_env()` is
+  *not* read here — the caller passes it) and resolves an optional positional
+  config-file path from `argv`. No real IO, no `System.halt`. This is what the
+  conformance harness calls.
+- `main(argv)` — the escript wrapper: `run(argv, env: System.get_env())`, then
+  `IO.write(stdout)`, `IO.write(:stderr, stderr)`, `System.halt(exit)`.
+- Command dispatch: default → boot a standalone instance; `--dump-config`,
+  `--ready`, `--version`/`-v`, `--help`/`-h`. Unknown flags → usage + nonzero.
+
+**`Bier.CLI.Config` (new, `lib/bier/cli/config.ex`)** — the PostgREST↔Bier
+config boundary.
+- `load(env_map, file_path_or_nil, flag_overrides) :: {:ok, keyword} |
+  {:error, message}` — reads sources, applies precedence, resolves aliases,
+  coerces types, and returns a keyword list ready for `Bier.start_link/1`
+  (Bier's snake_case atoms), or an error message for a fatal config problem.
+- `dump(keyword_or_struct) :: iodata` — PostgREST-format serialization
+  (`key = "value"` / bare ints / lowercase bools) of the loaded config, over the
+  keys Bier models. Deterministic ⇒ reparse-stable.
+- Owns the **mapping table** (single source of truth): canonical kebab key →
+  `{bier_atom, type, default, aliases, env_var}`.
+
+**`Bier.CLI.ConfigFile` (new, `lib/bier/cli/config_file.ex`)** — a small parser
+for the config-file subset (see below). `parse(contents) :: {:ok, map} |
+{:error, message}`.
+
+**`Bier.Config` (existing, extended)** — gains custom validators that emit
+PostgREST-exact messages (see Validation). These run inside `new!/2`, so
+`Bier.start_link/1` enforces them too.
+
+## Config mapping (PostgREST dialect → Bier)
+
+Only keys Bier implements appear. Direct mappings unless noted.
+
+| PostgREST key | `PGRST_*` env | Bier target | Notes |
+|---|---|---|---|
+| `db-uri` | `PGRST_DB_URI` | `hostname`,`port`,`database`,`username`,`password` | parse libpq URI into Bier's discrete fields |
+| `db-schemas` (alias `db-schema`) | `PGRST_DB_SCHEMAS` | `db_schemas` | CSV → list |
+| `db-anon-role` | `PGRST_DB_ANON_ROLE` | `db_anon_role` | |
+| `db-extra-search-path` | `PGRST_DB_EXTRA_SEARCH_PATH` | `db_extra_search_path` | emptyable CSV |
+| `db-max-rows` (alias `max-rows`) | `PGRST_DB_MAX_ROWS` | `db_max_rows` | opt-int |
+| `db-tx-end` | `PGRST_DB_TX_END` | `db_tx_end` | enum |
+| `db-pre-request` (alias `pre-request`) | `PGRST_DB_PRE_REQUEST` | `db_pre_request` | |
+| `db-root-spec` (alias `root-spec`) | `PGRST_DB_ROOT_SPEC` | `db_root_spec` | |
+| `server-port` | `PGRST_SERVER_PORT` | `router[:port]` | |
+| `server-host` | `PGRST_SERVER_HOST` | Bandit bind (router) | |
+| `admin-server-port` | `PGRST_ADMIN_SERVER_PORT` | `admin_server_port` | must differ from server-port |
+| `jwt-secret` | `PGRST_JWT_SECRET` | `jwt_secret` | ≥ 32 chars if symmetric |
+| `jwt-aud` | `PGRST_JWT_AUD` | `jwt_aud` | string or valid URI |
+| `openapi-mode` | `PGRST_OPENAPI_MODE` | `openapi_mode` | enum |
+| `log-level` | `PGRST_LOG_LEVEL` | `log_level` | enum |
+| `server-cors-allowed-origins` | `PGRST_SERVER_CORS_ALLOWED_ORIGINS` | `server_cors_allowed_origins` | |
+
+Keys present in the conformance cases but **not** mapped (deferred):
+`db-channel`, `server-unix-socket-mode`, `jwt-role-claim-key`,
+`jwt-secret-is-base64`, `openapi-server-proxy-uri`, `db-pool-*`,
+`app.settings.*`.
+
+## Sources & precedence
+
+`flags > PGRST_* env > config file > default`.
+
+This is PostgREST's order minus the DB-settings tier (deferred). Matches case
+1720 (env overrides file). Resolution per key: take the first present source;
+apply the key's coercion; on wrong type, treat as absent and fall back (case
+1721). Empty string for an opt-string key = absent (case 1723); emptyable CSV
+keys yield `[]` for empty (case 1728).
+
+## Config-file format
+
+A pragmatic subset of PostgREST's `configurator` format — enough for real
+configs and the cases, not full configurator parity:
+
+- `key = value` lines; `#` line comments; blank lines ignored.
+- String values double-quoted with `\"` escapes; bare integers; bare
+  `true`/`false`.
+- `app.settings.*` dotted keys parsed (stored, but not yet wired — only needed
+  if/when app-settings lands; for now an unknown-but-well-formed key is retained
+  for the dump round-trip, never fatal).
+- A **missing** config file (path given but not found) is fatal → nonzero exit
+  (case 1719).
+
+## Validation (shared, PostgREST-exact messages)
+
+Added as custom validators in the `Bier.Config` path so `start_link/1` and the
+CLI enforce identically. Each emits the exact substring the case asserts:
+
+| Case | Rule | Message substring |
+|---|---|---|
+| 1708 | jwt-secret ≥ 32 chars (symmetric) | `The JWT secret must be at least 32 characters long.` |
+| 1709 | jwt-aud string or valid URI | `jwt-aud should be a string or a valid URI` |
+| 1710 | openapi-mode ∈ enum | `Invalid openapi-mode. Check your configuration.` |
+| 1712 | log-level ∈ enum | `Invalid logging level. Check your configuration.` |
+| 1713 | db-tx-end ∈ enum | `Invalid transaction termination. Check your configuration.` |
+| 1717 | admin-server-port ≠ server-port | `admin-server-port cannot be the same as server-port` |
+
+A failed validation in the CLI prints the message to **stderr** and exits
+nonzero. (Within `start_link/1` it raises, as today.)
+
+## CLI surface
+
+- **default (no flag):** load config, validate, boot **one** standalone Bier
+  instance (name `Bier`), keep the VM alive. Standalone boot only; multi-instance
+  remains the embedded-library story.
+- `--dump-config`: load + validate, print PostgREST-format dump to stdout, exit 0.
+- `--ready`: issue a request to the admin server's `/ready`; exit 0/nonzero by
+  result. (Requires `admin-server-port` set.)
+- `-v` / `--version`: print version, exit 0.
+- `-h` / `--help`: usage, exit 0.
+- positional arg: config-file path.
+
+## Conformance harness changes
+
+- **`Bier.ConformanceCase`** already parses `kind: :cli`, `request.flag`, and
+  `config.env` / `config.file`. Add reading of `config.file` into a temp file
+  and `config.env` into a map for the CLI path (no change to the struct).
+- **New `Bier.CliCase` case template** (`test/support/cli_case.ex`), parallel to
+  `Bier.HttpCase`: `perform/1` writes any `config.file` to a temp path, then
+  calls `Bier.CLI.run(flag_args, env: case.config.env, file: temp_path)` and
+  returns `%{stdout, stderr, exit}`.
+- **New assertions** in `Bier.ConformanceAssertions`: `exit_code`
+  (`0` / `nonzero`), `dump_contains` (each string is a substring of stdout),
+  `stderr_contains`, `dump_reparse_stable` (write stdout to a file, re-run
+  `--dump-config` against it, assert byte-identical).
+- **`conformance_test.exs`** dispatch: route `c.kind == :cli` to the CLI path
+  instead of flunking. Replace the blanket `c.kind == :cli -> :cli` pending arm
+  with a narrower predicate that defers only cases touching unmodeled keys / the
+  full-table dump / db-config (reasons `:cli_parity`, `:unmodeled_key`,
+  `:db_config`).
+
+## Expected conformance disposition
+
+Pinned during build; current best estimate:
+
+- **Pass — validation:** 1708, 1709, 1710, 1712, 1713, 1717.
+- **Pass — file support:** 1719.
+- **Pass — dump (implemented keys):** likely 1706, 1720, 1721, 1722, 1723, 1728,
+  1730; 1726 (reparse-stable) plausible.
+- **Defer `:cli_parity`** (full table / example): 1705, 1727.
+- **Defer `:unmodeled_key`:** 1707 (mixed unimplemented aliases), 1711, 1714,
+  1715, 1716, 1718, 1729.
+- **Defer `:db_config`:** 1724, 1725.
+
+Any case that does not pass keeps an explicit, documented reason — no façade to
+force green.
+
+## Module layout
+
+```
+lib/bier/cli.ex              # Bier.CLI: run/2 core, main/1 escript, dispatch
+lib/bier/cli/config.ex       # Bier.CLI.Config: mapping table, load/3, dump/1
+lib/bier/cli/config_file.ex  # Bier.CLI.ConfigFile: parse/1
+lib/bier/config.ex           # extended: shared validators
+test/support/cli_case.ex     # Bier.CliCase
+test/support/conformance_assertions.ex  # + cli assertions
+mix.exs                      # escript: [main_module: Bier.CLI]
+```
+
+## Testing strategy
+
+- **TDD** per the project's workflow. The conformance cases are the acceptance
+  tests; drive each implemented-key case from red to green.
+- **Unit tests** for `Bier.CLI.Config` (precedence, alias resolution, coercion,
+  `db-uri` parsing, dump format) and `Bier.CLI.ConfigFile` (parse + error on
+  missing).
+- **Core is pure** ⇒ no IO capture needed in tests; assert the returned
+  `%{stdout, stderr, exit}` map directly. Escript `main/1` stays a thin,
+  untested-by-conformance wrapper (smoke-tested separately if cheap).
+- CI gates unchanged (`mix format`, `--warnings-as-errors`, `mix docs`, etc.).
+
+## Follow-up (separate issue)
+
+- `mix release` config + runtime config loader + Dockerfile to realize
+  `docker run bier` end-to-end.
+- Implement deferred keys (role-claim-key, socket-mode, base64 secret, …) to
+  retire their `:unmodeled_key` dispositions.
+- DB-role-settings (`db-config`) source for 1724/1725.

--- a/lib/bier/cli.ex
+++ b/lib/bier/cli.ex
@@ -1,0 +1,79 @@
+defmodule Bier.CLI do
+  @moduledoc """
+  Command-line interface for running Bier as a standalone, drop-in
+  PostgREST-compatible service.
+
+  `run/2` is the pure core: it takes argv plus an explicit environment and
+  returns `%{stdout, stderr, exit}` for terminal commands, or `{:boot,
+  resolved}` for the default run-the-server action. It performs no IO and never
+  halts — the conformance suite drives it directly. `main/1` (added separately)
+  is the escript wrapper that supplies real IO and `System.halt/1`.
+  """
+
+  alias Bier.CLI.{Config, ConfigFile}
+
+  @type result :: %{stdout: iodata(), stderr: iodata(), exit: non_neg_integer()}
+
+  @doc ~S"""
+  Run the CLI core. `opts[:env]` is a `%{"PGRST_*" => string}` map (defaults to
+  an empty map). Returns a `%{stdout, stderr, exit}` map for terminal commands,
+  or `{:boot, resolved}` for the default run-the-server action.
+  """
+  @spec run([String.t()], keyword()) :: result() | {:boot, map()}
+  def run(argv, opts \\ []) do
+    env = Keyword.get(opts, :env, %{})
+    {command, file_path} = parse_argv(argv)
+
+    with {:ok, file} <- read_file(file_path),
+         {:ok, resolved} <- Config.load(env, file, %{}) do
+      dispatch(command, resolved)
+    else
+      {:error, message} -> error(message)
+    end
+  end
+
+  defp dispatch(:version, _resolved), do: ok(version_line())
+  defp dispatch(:help, _resolved), do: ok(usage())
+  defp dispatch(:dump_config, resolved), do: ok(Config.dump(resolved))
+  defp dispatch(:run, resolved), do: {:boot, resolved}
+
+  # The optional positional config-file path is any argv element not starting
+  # with "-". Recognized flags select the command; default command is :run.
+  defp parse_argv(argv) do
+    file_path = Enum.find(argv, fn arg -> not String.starts_with?(arg, "-") end)
+    command = Enum.find_value(argv, :run, &flag_command/1)
+    {command, file_path}
+  end
+
+  defp flag_command("--dump-config"), do: :dump_config
+  defp flag_command("--version"), do: :version
+  defp flag_command("-v"), do: :version
+  defp flag_command("--help"), do: :help
+  defp flag_command("-h"), do: :help
+  defp flag_command(_), do: nil
+
+  defp read_file(nil), do: {:ok, nil}
+  defp read_file(path), do: ConfigFile.read(path)
+
+  defp version_line do
+    vsn = Application.spec(:bier, :vsn) || ~c"unknown"
+    "bier #{vsn}\n"
+  end
+
+  defp usage do
+    """
+    Usage: bier [CONFIG_FILE] [OPTIONS]
+
+    Runs Bier as a standalone PostgREST-compatible REST server. Config is read
+    from PGRST_* environment variables, an optional CONFIG_FILE, and flags.
+
+    Options:
+      --dump-config   Print the loaded configuration and exit
+      -v, --version   Print the version and exit
+      -h, --help      Print this help and exit
+    """
+  end
+
+  defp ok(stdout), do: %{stdout: stdout, stderr: "", exit: 0}
+  defp error(message), do: %{stdout: "", stderr: [message, "\n"], exit: 1}
+end

--- a/lib/bier/cli.ex
+++ b/lib/bier/cli.ex
@@ -14,6 +14,8 @@ defmodule Bier.CLI do
 
   @type result :: %{stdout: iodata(), stderr: iodata(), exit: non_neg_integer()}
 
+  @version Mix.Project.config()[:version]
+
   @doc ~S"""
   Run the CLI core. `opts[:env]` is a `%{"PGRST_*" => string}` map (defaults to
   an empty map). Returns a `%{stdout, stderr, exit}` map for terminal commands,
@@ -59,10 +61,7 @@ defmodule Bier.CLI do
   defp read_file(nil), do: {:ok, nil}
   defp read_file(path), do: ConfigFile.read(path)
 
-  defp version_line do
-    vsn = Application.spec(:bier, :vsn) || ~c"unknown"
-    "bier #{vsn}\n"
-  end
+  defp version_line, do: "bier #{@version}\n"
 
   defp usage do
     """
@@ -76,6 +75,31 @@ defmodule Bier.CLI do
       -v, --version   Print the version and exit
       -h, --help      Print this help and exit
     """
+  end
+
+  @doc """
+  escript entry point. Supplies the real process environment, writes the
+  command's output to stdout/stderr, and halts with its exit code. For the
+  default run action it boots one standalone Bier instance and blocks.
+  """
+  @spec main([String.t()]) :: no_return()
+  def main(argv) do
+    case run(argv, env: System.get_env()) do
+      {:boot, resolved} -> boot(resolved)
+      %{stdout: out, stderr: err, exit: code} -> emit(out, err, code)
+    end
+  end
+
+  defp emit(out, err, code) do
+    IO.write(out)
+    IO.write(:stderr, err)
+    System.halt(code)
+  end
+
+  defp boot(resolved) do
+    {:ok, _} = Application.ensure_all_started(:bier)
+    {:ok, _pid} = Bier.start_link(Config.to_start_opts(resolved))
+    Process.sleep(:infinity)
   end
 
   defp ok(stdout), do: %{stdout: stdout, stderr: "", exit: 0}

--- a/lib/bier/cli.ex
+++ b/lib/bier/cli.ex
@@ -38,7 +38,11 @@ defmodule Bier.CLI do
   defp dispatch(:run, resolved), do: {:boot, resolved}
 
   # The optional positional config-file path is any argv element not starting
-  # with "-". Recognized flags select the command; default command is :run.
+  # with "-". The first recognized flag selects the command; the default is
+  # :run. Unknown flags are currently ignored (the server boots), and when two
+  # commands are passed the first wins — PostgREST instead errors on unknown /
+  # conflicting flags. Tightening this belongs with the deferred --ready /
+  # --example work (issue #45), not this conformance slice.
   defp parse_argv(argv) do
     file_path = Enum.find(argv, fn arg -> not String.starts_with?(arg, "-") end)
     command = Enum.find_value(argv, :run, &flag_command/1)

--- a/lib/bier/cli/config.ex
+++ b/lib/bier/cli/config.ex
@@ -1,0 +1,207 @@
+defmodule Bier.CLI.Config do
+  @moduledoc """
+  The PostgREST config dialect ↔ Bier boundary.
+
+  `spec/0` is the single source of truth: one entry per PostgREST config key
+  that Bier implements, carrying its `PGRST_*` env var, deprecated aliases,
+  value type, and PostgREST default (used for `--dump-config`). Keys Bier does
+  not implement are intentionally absent — their conformance cases stay
+  deferred.
+  """
+
+  # kind:
+  #   :string | :opt_string | :int | :opt_int | :bool
+  #   :csv | :csv_emptyable
+  #   {:enum_atom, name} | {:enum_str, name}
+  # default: the PostgREST default, rendered by dump/1 when unset.
+  @entries [
+    %{key: "db-uri", env: "PGRST_DB_URI", kind: :string, default: "postgresql://", aliases: []},
+    %{
+      key: "db-schemas",
+      env: "PGRST_DB_SCHEMAS",
+      kind: :csv,
+      default: ["public"],
+      aliases: ["db-schema"]
+    },
+    %{
+      key: "db-anon-role",
+      env: "PGRST_DB_ANON_ROLE",
+      kind: :opt_string,
+      default: :unset,
+      aliases: []
+    },
+    %{
+      key: "db-extra-search-path",
+      env: "PGRST_DB_EXTRA_SEARCH_PATH",
+      kind: :csv_emptyable,
+      default: ["public"],
+      aliases: []
+    },
+    %{
+      key: "db-max-rows",
+      env: "PGRST_DB_MAX_ROWS",
+      kind: :opt_int,
+      default: :unset,
+      aliases: ["max-rows"]
+    },
+    %{
+      key: "db-tx-end",
+      env: "PGRST_DB_TX_END",
+      kind: {:enum_atom, :db_tx_end},
+      default: :commit,
+      aliases: []
+    },
+    %{
+      key: "db-pre-request",
+      env: "PGRST_DB_PRE_REQUEST",
+      kind: :opt_string,
+      default: :unset,
+      aliases: ["pre-request"]
+    },
+    %{
+      key: "db-root-spec",
+      env: "PGRST_DB_ROOT_SPEC",
+      kind: :opt_string,
+      default: :unset,
+      aliases: ["root-spec"]
+    },
+    %{key: "server-port", env: "PGRST_SERVER_PORT", kind: :int, default: 3000, aliases: []},
+    %{
+      key: "admin-server-port",
+      env: "PGRST_ADMIN_SERVER_PORT",
+      kind: :opt_int,
+      default: :unset,
+      aliases: []
+    },
+    %{
+      key: "jwt-secret",
+      env: "PGRST_JWT_SECRET",
+      kind: :opt_string,
+      default: :unset,
+      aliases: []
+    },
+    %{key: "jwt-aud", env: "PGRST_JWT_AUD", kind: :opt_string, default: :unset, aliases: []},
+    %{
+      key: "openapi-mode",
+      env: "PGRST_OPENAPI_MODE",
+      kind: {:enum_str, :openapi_mode},
+      default: "follow-privileges",
+      aliases: []
+    },
+    %{
+      key: "log-level",
+      env: "PGRST_LOG_LEVEL",
+      kind: {:enum_atom, :log_level},
+      default: :error,
+      aliases: []
+    },
+    %{
+      key: "server-cors-allowed-origins",
+      env: "PGRST_SERVER_CORS_ALLOWED_ORIGINS",
+      kind: :opt_string,
+      default: :unset,
+      aliases: []
+    }
+  ]
+
+  @enum_atoms %{
+    log_level: %{
+      values: %{
+        "crit" => :crit,
+        "error" => :error,
+        "warn" => :warn,
+        "info" => :info,
+        "debug" => :debug
+      },
+      message: "Invalid logging level. Check your configuration."
+    },
+    db_tx_end: %{
+      values: %{
+        "commit" => :commit,
+        "commit-allow-override" => :"commit-allow-override",
+        "rollback" => :rollback,
+        "rollback-allow-override" => :"rollback-allow-override"
+      },
+      message: "Invalid transaction termination. Check your configuration."
+    }
+  }
+
+  @enum_strs %{
+    openapi_mode: %{
+      values: ["follow-privileges", "ignore-privileges", "disabled"],
+      message: "Invalid openapi-mode. Check your configuration."
+    }
+  }
+
+  @doc "The config key spec table (one entry per implemented PostgREST key)."
+  @spec spec() :: [map()]
+  def spec, do: @entries
+
+  @doc """
+  Coerce a raw value (string from env/file, or already-typed from the file
+  parser) to the typed value for `kind`. `:unset` marks an absent optional
+  value (falls back to default). Enum mismatches return PostgREST's message.
+  """
+  @spec coerce(term(), term()) :: {:ok, term()} | {:error, String.t()}
+  def coerce(:string, v), do: {:ok, to_string(v)}
+
+  def coerce(:opt_string, v) do
+    case to_string(v) do
+      "" -> {:ok, :unset}
+      s -> {:ok, s}
+    end
+  end
+
+  def coerce(:int, v) do
+    case parse_int(v) do
+      {:ok, int} -> {:ok, int}
+      :error -> {:ok, :unset}
+    end
+  end
+
+  def coerce(:opt_int, v) do
+    case parse_int(v) do
+      {:ok, int} -> {:ok, int}
+      :error -> {:ok, :unset}
+    end
+  end
+
+  def coerce(:bool, v), do: {:ok, v in [true, "true", "1", 1]}
+
+  def coerce(:csv, v), do: {:ok, split_csv(to_string(v))}
+
+  def coerce(:csv_emptyable, v) do
+    case to_string(v) do
+      "" -> {:ok, []}
+      s -> {:ok, split_csv(s)}
+    end
+  end
+
+  def coerce({:enum_atom, name}, v) do
+    %{values: values, message: message} = Map.fetch!(@enum_atoms, name)
+
+    case Map.fetch(values, to_string(v)) do
+      {:ok, atom} -> {:ok, atom}
+      :error -> {:error, message}
+    end
+  end
+
+  def coerce({:enum_str, name}, v) do
+    %{values: values, message: message} = Map.fetch!(@enum_strs, name)
+    s = to_string(v)
+    if s in values, do: {:ok, s}, else: {:error, message}
+  end
+
+  defp parse_int(v) when is_integer(v), do: {:ok, v}
+
+  defp parse_int(v) do
+    case Integer.parse(to_string(v)) do
+      {int, ""} -> {:ok, int}
+      _ -> :error
+    end
+  end
+
+  defp split_csv(s) do
+    s |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == ""))
+  end
+end

--- a/lib/bier/cli/config.ex
+++ b/lib/bier/cli/config.ex
@@ -324,4 +324,27 @@ defmodule Bier.CLI.Config do
         :ok
     end
   end
+
+  @doc """
+  Render a resolved config map as PostgREST `--dump-config` text: one
+  `key = value` line per spec key, sorted by key for determinism (so the output
+  is reparse-stable).
+  """
+  @spec dump(map()) :: iodata()
+  def dump(resolved) do
+    spec()
+    |> Enum.map(& &1.key)
+    |> Enum.sort()
+    |> Enum.map(fn key -> [key, " = ", render(Map.fetch!(resolved, key)), "\n"] end)
+  end
+
+  defp render(:unset), do: ~s("")
+  defp render(value) when is_integer(value), do: Integer.to_string(value)
+  defp render(true), do: "true"
+  defp render(false), do: "false"
+  defp render(value) when is_list(value), do: quote_string(Enum.join(value, ","))
+  defp render(value) when is_atom(value), do: quote_string(Atom.to_string(value))
+  defp render(value) when is_binary(value), do: quote_string(value)
+
+  defp quote_string(s), do: [?", String.replace(s, ~S("), ~S(\")), ?"]
 end

--- a/lib/bier/cli/config.ex
+++ b/lib/bier/cli/config.ex
@@ -229,4 +229,99 @@ defmodule Bier.CLI.Config do
   defp split_csv(s) do
     s |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == ""))
   end
+
+  @doc """
+  Resolve every spec key from flags > env > file > default, applying aliases and
+  coercion, then run the shared semantic validators. Returns the resolved
+  `%{kebab_key => typed_value}` map, or `{:error, message}` on a fatal problem.
+
+  `env` is a `%{"PGRST_*" => string}` map (the caller supplies it — the core
+  never reads `System.get_env/0`). `file` is `nil` or a `%{kebab_key => raw}`
+  map (already parsed). `flags` is a `%{kebab_key => raw}` map of command-line
+  overrides.
+  """
+  @spec load(map(), map() | nil, map()) :: {:ok, map()} | {:error, String.t()}
+  def load(env, file, flags) do
+    file = file || %{}
+
+    spec()
+    |> Enum.reduce_while({:ok, %{}}, fn entry, {:ok, acc} ->
+      case resolve(entry, env, file, flags) do
+        {:ok, value} -> {:cont, {:ok, Map.put(acc, entry.key, value)}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+    |> validate()
+  end
+
+  defp resolve(entry, env, file, flags) do
+    case raw_source(entry, env, file, flags) do
+      :absent ->
+        {:ok, entry.default}
+
+      {:present, raw} ->
+        case coerce(entry.kind, raw) do
+          # A wrong-typed/unparseable value coerces to :unset, which means
+          # "fall back to the key's default" (PostgREST's wrong-type rule).
+          {:ok, :unset} -> {:ok, entry.default}
+          other -> other
+        end
+    end
+  end
+
+  # Precedence: flags > env > file. Aliases are consulted for file keys only
+  # (PostgREST aliases are file/env spellings; flags use canonical keys).
+  defp raw_source(entry, env, file, flags) do
+    cond do
+      present?(entry, Map.get(flags, entry.key)) -> {:present, Map.fetch!(flags, entry.key)}
+      present?(entry, Map.get(env, entry.env)) -> {:present, Map.fetch!(env, entry.env)}
+      true -> file_source(entry, file)
+    end
+  end
+
+  defp file_source(entry, file) do
+    keys = [entry.key | entry.aliases]
+
+    case Enum.find(keys, fn k -> present?(entry, Map.get(file, k)) end) do
+      nil -> :absent
+      key -> {:present, Map.fetch!(file, key)}
+    end
+  end
+
+  # nil/missing is absent. An empty string is absent for every kind EXCEPT
+  # :csv_emptyable, where "" is a meaningful value (the empty list) — PostgREST's
+  # splitOnCommasEmptyable (case 1728). Any other value is present.
+  defp present?(_entry, nil), do: false
+  defp present?(%{kind: :csv_emptyable}, ""), do: true
+  defp present?(_entry, ""), do: false
+  defp present?(_entry, _), do: true
+
+  defp validate({:error, _} = err), do: err
+
+  defp validate({:ok, resolved}) do
+    with :ok <- run_validator(resolved, "jwt-secret", &Bier.Config.validate_jwt_secret/1),
+         :ok <- run_validator(resolved, "jwt-aud", &Bier.Config.validate_jwt_aud/1),
+         :ok <- validate_admin_port(resolved) do
+      {:ok, resolved}
+    end
+  end
+
+  defp run_validator(resolved, key, fun) do
+    case Map.get(resolved, key) do
+      :unset -> :ok
+      value -> fun.(value)
+    end
+  end
+
+  # admin-server-port must differ from server-port (case 1717). server-port has
+  # a default, so it is always an integer; admin-server-port may be :unset.
+  defp validate_admin_port(resolved) do
+    case {Map.get(resolved, "admin-server-port"), Map.get(resolved, "server-port")} do
+      {port, port} when is_integer(port) ->
+        {:error, "admin-server-port cannot be the same as server-port"}
+
+      _ ->
+        :ok
+    end
+  end
 end

--- a/lib/bier/cli/config.ex
+++ b/lib/bier/cli/config.ex
@@ -326,6 +326,64 @@ defmodule Bier.CLI.Config do
   end
 
   @doc """
+  Translate a resolved config map into a keyword list for `Bier.start_link/1`.
+  `:unset` optional keys are omitted so Bier's own defaults apply. `db-uri` is
+  parsed into discrete connection fields; `server-port` maps to `router[:port]`.
+  """
+  @spec to_start_opts(map()) :: keyword()
+  def to_start_opts(resolved) do
+    direct =
+      [
+        db_schemas: resolved["db-schemas"],
+        db_anon_role: resolved["db-anon-role"],
+        db_extra_search_path: resolved["db-extra-search-path"],
+        db_max_rows: resolved["db-max-rows"],
+        db_tx_end: bier_tx_end(resolved["db-tx-end"]),
+        db_pre_request: resolved["db-pre-request"],
+        db_root_spec: resolved["db-root-spec"],
+        admin_server_port: resolved["admin-server-port"],
+        jwt_secret: resolved["jwt-secret"],
+        jwt_aud: resolved["jwt-aud"],
+        openapi_mode: resolved["openapi-mode"],
+        log_level: resolved["log-level"],
+        server_cors_allowed_origins: resolved["server-cors-allowed-origins"]
+      ]
+      |> Enum.reject(fn {_k, v} -> v == :unset end)
+
+    router = [port: resolved["server-port"], scheme: :http]
+
+    direct ++ [router: router] ++ db_uri_opts(resolved["db-uri"])
+  end
+
+  # Bier's runtime supports only :commit / :rollback. PostgREST's
+  # *-allow-override variants (per-request Prefer override) collapse to their
+  # base mode — the closest behavior Bier currently offers.
+  defp bier_tx_end(v) when v in [:commit, :"commit-allow-override"], do: :commit
+  defp bier_tx_end(v) when v in [:rollback, :"rollback-allow-override"], do: :rollback
+
+  # Parse a libpq URI into Bier's discrete connection fields. An empty
+  # "postgresql://" carries no fields, so Bier's defaults apply.
+  defp db_uri_opts(uri) when uri in [nil, "", "postgresql://", "postgres://"], do: []
+
+  defp db_uri_opts(uri) do
+    %URI{host: host, port: port, path: path, userinfo: userinfo} = URI.parse(uri)
+    {user, pass} = split_userinfo(userinfo)
+    database = path |> to_string() |> String.trim_leading("/")
+
+    [hostname: host, port: port, database: database, username: user, password: pass]
+    |> Enum.reject(fn {_k, v} -> v in [nil, ""] end)
+  end
+
+  defp split_userinfo(nil), do: {nil, nil}
+
+  defp split_userinfo(userinfo) do
+    case String.split(userinfo, ":", parts: 2) do
+      [user, pass] -> {user, pass}
+      [user] -> {user, nil}
+    end
+  end
+
+  @doc """
   Render a resolved config map as PostgREST `--dump-config` text: one
   `key = value` line per spec key, sorted by key for determinism (so the output
   is reparse-stable).

--- a/lib/bier/cli/config.ex
+++ b/lib/bier/cli/config.ex
@@ -137,12 +137,23 @@ defmodule Bier.CLI.Config do
   @spec spec() :: [map()]
   def spec, do: @entries
 
+  @type kind ::
+          :string
+          | :opt_string
+          | :int
+          | :opt_int
+          | :bool
+          | :csv
+          | :csv_emptyable
+          | {:enum_atom, atom()}
+          | {:enum_str, atom()}
+
   @doc """
   Coerce a raw value (string from env/file, or already-typed from the file
   parser) to the typed value for `kind`. `:unset` marks an absent optional
   value (falls back to default). Enum mismatches return PostgREST's message.
   """
-  @spec coerce(term(), term()) :: {:ok, term()} | {:error, String.t()}
+  @spec coerce(kind(), term()) :: {:ok, term()} | {:error, String.t()}
   def coerce(:string, v), do: {:ok, to_string(v)}
 
   def coerce(:opt_string, v) do
@@ -166,7 +177,21 @@ defmodule Bier.CLI.Config do
     end
   end
 
-  def coerce(:bool, v), do: {:ok, v in [true, "true", "1", 1]}
+  # Mirrors PostgREST's coerceBool: case-insensitive "true" and any positive
+  # integer (as a string or number) are truthy; everything else is false.
+  def coerce(:bool, v) when is_boolean(v), do: {:ok, v}
+
+  def coerce(:bool, v) when is_integer(v), do: {:ok, v > 0}
+
+  def coerce(:bool, v) do
+    s = v |> to_string() |> String.downcase()
+
+    truthy =
+      s == "true" or
+        match?({n, ""} when n > 0, Integer.parse(s))
+
+    {:ok, truthy}
+  end
 
   def coerce(:csv, v), do: {:ok, split_csv(to_string(v))}
 

--- a/lib/bier/cli/config.ex
+++ b/lib/bier/cli/config.ex
@@ -101,6 +101,27 @@ defmodule Bier.CLI.Config do
       kind: :opt_string,
       default: :unset,
       aliases: []
+    },
+    %{
+      key: "db-plan-enabled",
+      env: "PGRST_DB_PLAN_ENABLED",
+      kind: :bool,
+      default: false,
+      aliases: []
+    },
+    %{
+      key: "server-trace-header",
+      env: "PGRST_SERVER_TRACE_HEADER",
+      kind: :opt_string,
+      default: :unset,
+      aliases: []
+    },
+    %{
+      key: "server-timing-enabled",
+      env: "PGRST_SERVER_TIMING_ENABLED",
+      kind: :bool,
+      default: false,
+      aliases: []
     }
   ]
 
@@ -346,7 +367,10 @@ defmodule Bier.CLI.Config do
         jwt_aud: resolved["jwt-aud"],
         openapi_mode: resolved["openapi-mode"],
         log_level: resolved["log-level"],
-        server_cors_allowed_origins: resolved["server-cors-allowed-origins"]
+        server_cors_allowed_origins: resolved["server-cors-allowed-origins"],
+        db_plan_enabled: resolved["db-plan-enabled"],
+        server_trace_header: resolved["server-trace-header"],
+        server_timing_enabled: resolved["server-timing-enabled"]
       ]
       |> Enum.reject(fn {_k, v} -> v == :unset end)
 

--- a/lib/bier/cli/config.ex
+++ b/lib/bier/cli/config.ex
@@ -368,20 +368,26 @@ defmodule Bier.CLI.Config do
   defp db_uri_opts(uri) do
     %URI{host: host, port: port, path: path, userinfo: userinfo} = URI.parse(uri)
     {user, pass} = split_userinfo(userinfo)
-    database = path |> to_string() |> String.trim_leading("/")
+    database = path |> to_string() |> String.trim_leading("/") |> decode()
 
     [hostname: host, port: port, database: database, username: user, password: pass]
     |> Enum.reject(fn {_k, v} -> v in [nil, ""] end)
   end
 
+  # URI.parse/1 leaves percent-encoding intact, but Postgrex expects decoded
+  # credentials/db name (a password is commonly encoded because `@`/`:` are URI
+  # delimiters, e.g. `p%40ss` -> `p@ss`).
   defp split_userinfo(nil), do: {nil, nil}
 
   defp split_userinfo(userinfo) do
     case String.split(userinfo, ":", parts: 2) do
-      [user, pass] -> {user, pass}
-      [user] -> {user, nil}
+      [user, pass] -> {decode(user), decode(pass)}
+      [user] -> {decode(user), nil}
     end
   end
+
+  defp decode(nil), do: nil
+  defp decode(value), do: URI.decode(value)
 
   @doc """
   Render a resolved config map as PostgREST `--dump-config` text: one

--- a/lib/bier/cli/config_file.ex
+++ b/lib/bier/cli/config_file.ex
@@ -44,9 +44,15 @@ defmodule Bier.CLI.ConfigFile do
     end
   end
 
-  defp parse_value(<<?", rest::binary>>) do
-    rest
-    |> String.slice(0, byte_size(rest) - 1)
+  # A double-quoted string: strip the surrounding quotes and unescape \" → ".
+  # The guard requires a non-empty suffix that ends with a closing quote, so
+  # `""` parses to "" and an unterminated `"foo` falls through to the
+  # bare-string clause below.
+  defp parse_value(<<?", inner::binary>>)
+       when byte_size(inner) >= 1 and
+              binary_part(inner, byte_size(inner) - 1, 1) == "\"" do
+    inner
+    |> binary_part(0, byte_size(inner) - 1)
     |> String.replace(~S(\"), ~S("))
   end
 

--- a/lib/bier/cli/config_file.ex
+++ b/lib/bier/cli/config_file.ex
@@ -1,0 +1,62 @@
+defmodule Bier.CLI.ConfigFile do
+  @moduledoc """
+  Parses the PostgREST-compatible config-file subset into a
+  `%{kebab_key => raw_value}` map: `key = value` lines, `#` comments, blank
+  lines, double-quoted strings (with `\\"` escapes), bare integers, and bare
+  `true`/`false`. Raw values are returned untyped; `Bier.CLI.Config` coerces
+  them per the target key.
+  """
+
+  @doc "Read and parse a config file. A missing file is a fatal error."
+  @spec read(Path.t()) :: {:ok, map()} | {:error, String.t()}
+  def read(path) do
+    case File.read(path) do
+      {:ok, contents} ->
+        parse(contents)
+
+      {:error, reason} ->
+        {:error, "could not read config file #{path}: #{:file.format_error(reason)}"}
+    end
+  end
+
+  @doc "Parse config-file contents."
+  @spec parse(String.t()) :: {:ok, map()} | {:error, String.t()}
+  def parse(contents) do
+    contents
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == "" or String.starts_with?(&1, "#")))
+    |> Enum.reduce_while({:ok, %{}}, fn line, {:ok, acc} ->
+      case parse_line(line) do
+        {:ok, {key, value}} -> {:cont, {:ok, Map.put(acc, key, value)}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp parse_line(line) do
+    case String.split(line, "=", parts: 2) do
+      [raw_key, raw_value] ->
+        {:ok, {String.trim(raw_key), parse_value(String.trim(raw_value))}}
+
+      _ ->
+        {:error, "malformed config line: #{inspect(line)}"}
+    end
+  end
+
+  defp parse_value(<<?", rest::binary>>) do
+    rest
+    |> String.slice(0, byte_size(rest) - 1)
+    |> String.replace(~S(\"), ~S("))
+  end
+
+  defp parse_value("true"), do: true
+  defp parse_value("false"), do: false
+
+  defp parse_value(value) do
+    case Integer.parse(value) do
+      {int, ""} -> int
+      _ -> value
+    end
+  end
+end

--- a/lib/bier/config.ex
+++ b/lib/bier/config.ex
@@ -115,32 +115,26 @@ defmodule Bier.Config do
 
   @doc """
   `jwt-aud` may be any plain string, but a value containing ':' must parse as a
-  valid absolute URI (scheme + host). Mirrors PostgREST conformance case 1709.
+  valid absolute URI. Mirrors PostgREST conformance case 1709.
   """
   @spec validate_jwt_aud(String.t() | nil) :: :ok | {:error, String.t()}
   def validate_jwt_aud(nil), do: :ok
 
   def validate_jwt_aud(aud) when is_binary(aud) do
-    cond do
-      not String.contains?(aud, ":") ->
-        :ok
-
-      valid_uri?(aud) ->
-        :ok
-
-      true ->
-        {:error, "jwt-aud should be a string or a valid URI"}
+    if not String.contains?(aud, ":") or valid_uri?(aud) do
+      :ok
+    else
+      {:error, "jwt-aud should be a string or a valid URI"}
     end
   end
 
+  # Mirrors PostgREST's `isURI` (Network.URI): any absolute RFC 3986 URI is
+  # valid, including opaque URIs / URNs (scheme, no authority) like
+  # "urn:example:audience". A host is NOT required.
   defp valid_uri?(value) do
     case URI.new(value) do
-      {:ok, %URI{scheme: scheme, host: host}}
-      when is_binary(scheme) and is_binary(host) and host != "" ->
-        true
-
-      _ ->
-        false
+      {:ok, %URI{scheme: scheme}} when is_binary(scheme) and scheme != "" -> true
+      _ -> false
     end
   end
 

--- a/lib/bier/config.ex
+++ b/lib/bier/config.ex
@@ -92,8 +92,56 @@ defmodule Bier.Config do
     conf = NimbleOptions.validate!(opts, schema)
 
     validate_admin_server_port!(conf)
+    raise_if_error!(validate_jwt_secret(conf[:jwt_secret]))
+    raise_if_error!(validate_jwt_aud(conf[:jwt_aud]))
 
     struct!(__MODULE__, conf)
+  end
+
+  @doc """
+  A symmetric (text) JWT secret must be at least 32 characters long. `nil`
+  (no secret configured) is allowed. Mirrors PostgREST conformance case 1708.
+  """
+  @spec validate_jwt_secret(String.t() | nil) :: :ok | {:error, String.t()}
+  def validate_jwt_secret(nil), do: :ok
+
+  def validate_jwt_secret(secret) when is_binary(secret) do
+    if String.length(secret) >= 32 do
+      :ok
+    else
+      {:error, "The JWT secret must be at least 32 characters long."}
+    end
+  end
+
+  @doc """
+  `jwt-aud` may be any plain string, but a value containing ':' must parse as a
+  valid absolute URI (scheme + host). Mirrors PostgREST conformance case 1709.
+  """
+  @spec validate_jwt_aud(String.t() | nil) :: :ok | {:error, String.t()}
+  def validate_jwt_aud(nil), do: :ok
+
+  def validate_jwt_aud(aud) when is_binary(aud) do
+    cond do
+      not String.contains?(aud, ":") ->
+        :ok
+
+      valid_uri?(aud) ->
+        :ok
+
+      true ->
+        {:error, "jwt-aud should be a string or a valid URI"}
+    end
+  end
+
+  defp valid_uri?(value) do
+    case URI.new(value) do
+      {:ok, %URI{scheme: scheme, host: host}}
+      when is_binary(scheme) and is_binary(host) and host != "" ->
+        true
+
+      _ ->
+        false
+    end
   end
 
   # PostgREST rejects an admin-server-port equal to server-port at startup
@@ -108,4 +156,7 @@ defmodule Bier.Config do
       raise ArgumentError, "admin-server-port cannot be the same as server-port"
     end
   end
+
+  defp raise_if_error!(:ok), do: :ok
+  defp raise_if_error!({:error, message}), do: raise(ArgumentError, message)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule Bier.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],
       aliases: aliases(),
+      escript: escript(),
       deps: deps()
     ]
   end
@@ -36,6 +37,10 @@ defmodule Bier.MixProject do
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
+
+  defp escript do
+    [main_module: Bier.CLI, app: nil]
+  end
 
   defp aliases do
     [

--- a/spec/COVERAGE.md
+++ b/spec/COVERAGE.md
@@ -35,14 +35,14 @@ Pinned target: **PostgREST v14.12**. Total cases: **532** across 17 areas.
 | Docs page (`references/...`) | Covering case ids | Notes |
 |------------------------------|-------------------|-------|
 | `auth` (Authentication) | 1450–1494 (auth) | JWT validation/claims, roles, anonymous, audience, pre-request, GUC claims, login token minting. |
-| `cli` (CLI) | 1705–1707, 1726, 1727 (config dump-config/example flag) | `--dump-config`, `--example`, config dump idempotence. |
+| `cli` (CLI) | 1705–1730 (config CLI cases) | `--dump-config`, validation, env/file/precedence, coercion, aliases. Implemented by `Bier.CLI` (escript + in-process core), driven in-process by `Bier.CliCase`. Most cases pass; full-table dump (1705) and `--example` (1727) deferred as `:cli_parity`. See **Scope decisions**. |
 | `transactions` (Transactions) | 1387–1392 (safe-update/delete, max-affected), 1722 (db-tx-end), 1713 (db-tx-end validation), 1759 (transaction timing) | Tx-scoped GUCs, safe-update/safe-delete (rollback on missing WHERE), db-tx-end. Partial — no explicit characteristics/isolation-level case. |
 | `connection_pool` (Connection Pool) | — (OUT OF SCOPE) | Pool sizing/acquisition behavior is operational and not observable as deterministic black-box HTTP. See **Scope decisions**. Config surface lives at `db-pool`, `db-pool-acquisition-timeout`, `db-pool-max-lifetime`, `db-pool-max-idletime` (alias `db-pool-timeout`), `db-pool-automatic-recovery` — those keys are exercised for parsing/aliasing by the config area (e.g. 1707). |
 | `schema_cache` (Schema Cache) | — (DEFERRED) | Schema-cache reload (`NOTIFY pgrst, 'reload schema'` / SIGUSR1) needs a reload-signal harness. See **Scope decisions**. |
 | `errors` (Errors) | 1500–1516 (errors), 1432–1434 (rpc errors), 1024, 1185 (not-found), 1455–1464 (auth JWT errors) | SQLSTATE→HTTP mapping, PGRST error codes, RAISE PGRST full control, 4xx/5xx envelopes. |
 | `configuration` (Configuration) | 1700–1730 (config) | Sources (env/file/db-role-settings), aliases, validation, coercion, precedence, app-settings. |
 | `observability` (Observability) | 1750–1767 (observability) | Server-Timing, trace header, log-level→status logging. |
-| `admin_server` (Admin Server) | 1717 (admin-port = server-port fatal) | Port-collision validation (case 1717, library-enforced in `Bier.Config`) plus `/live`/`/ready` covered by ExUnit (`test/bier/admin_server_test.exs`). Partial — case 1717 stays `:pending` (CLI `--dump-config`), `/metrics` not yet implemented. |
+| `admin_server` (Admin Server) | 1717 (admin-port = server-port fatal) | Port-collision validation (case 1717, library-enforced in `Bier.Config`) plus `/live`/`/ready` covered by ExUnit (`test/bier/admin_server_test.exs`). Partial — case 1717 now runs via the CLI harness (`Bier.CliCase`); `/metrics` not yet implemented. |
 | `listener` (Listener) | — (DEFERRED) | LISTEN/NOTIFY channel (`db-channel`) reload trigger needs the same reload-signal harness. See **Scope decisions**. |
 
 ## Scope decisions
@@ -71,6 +71,19 @@ This pass formalizes which uncovered docs pages are intentional vs. true gaps.
 - **`listener` — DEFERRED (future work).** The LISTEN/NOTIFY channel
   (`db-channel`, `db-channel-enabled`) is the transport for the same
   reload-signal harness. Deferred together with `schema_cache`.
+
+- **`cli` (config CLI cases 1705–1730) — now COVERED, with honest deferrals.**
+  `Bier.CLI` provides a standalone, drop-in PostgREST-compatible CLI (`PGRST_*`
+  env, kebab config file, `--dump-config`), driven in-process by `Bier.CliCase`.
+  The 15 cases that map onto config Bier implements pass (1706, 1708–1710,
+  1712, 1713, 1717, 1719–1723, 1726, 1728, 1730). The rest keep an explicit
+  `pending_reason` instead of a parity façade: `:cli_parity` (full default-table
+  dump 1705, `--example` 1727 — would require modeling keys Bier does not
+  implement); `:unmodeled_key` (1707, 1711, 1714, 1715, 1716, 1718, 1729 —
+  `jwt-role-claim-key`, `server-unix-socket-mode`, `openapi-server-proxy-uri`,
+  `jwt-secret-is-base64`, `app.settings.*`); `:db_config` (1724, 1725 — DB
+  role-settings source, needs a live connection at parse time). Standalone
+  packaging (`mix release` + Dockerfile) and `--ready` are tracked in #45.
 
 ## Coverage summary
 

--- a/test/bier/cli/config_file_test.exs
+++ b/test/bier/cli/config_file_test.exs
@@ -1,0 +1,41 @@
+defmodule Bier.CLI.ConfigFileTest do
+  use ExUnit.Case, async: true
+
+  alias Bier.CLI.ConfigFile
+
+  test "parses quoted strings, bare ints and bools, ignores comments/blanks" do
+    contents = """
+    # a comment
+    db-schemas = "api,public"
+
+    server-port = 3000
+    jwt-secret-is-base64 = true
+    """
+
+    assert ConfigFile.parse(contents) ==
+             {:ok,
+              %{
+                "db-schemas" => "api,public",
+                "server-port" => 3000,
+                "jwt-secret-is-base64" => true
+              }}
+  end
+
+  test "unquotes escaped quotes inside string values" do
+    assert ConfigFile.parse(~S(role-claim-key = ".\"role\"")) ==
+             {:ok, %{"role-claim-key" => ~S(."role")}}
+  end
+
+  test "read/1 errors on a missing file" do
+    assert {:error, message} = ConfigFile.read("does_not_exist.conf")
+    assert message =~ "does_not_exist.conf"
+  end
+
+  test "read/1 parses an existing file" do
+    path = Path.join(System.tmp_dir!(), "bier_cfg_#{System.unique_integer([:positive])}.conf")
+    File.write!(path, "log-level = \"info\"\n")
+    on_exit(fn -> File.rm(path) end)
+
+    assert ConfigFile.read(path) == {:ok, %{"log-level" => "info"}}
+  end
+end

--- a/test/bier/cli/config_file_test.exs
+++ b/test/bier/cli/config_file_test.exs
@@ -38,4 +38,18 @@ defmodule Bier.CLI.ConfigFileTest do
 
     assert ConfigFile.read(path) == {:ok, %{"log-level" => "info"}}
   end
+
+  test "an empty quoted string parses to an empty string" do
+    assert ConfigFile.parse(~s(jwt-secret = "")) == {:ok, %{"jwt-secret" => ""}}
+  end
+
+  test "a value containing '=' keeps everything after the first '='" do
+    assert ConfigFile.parse("db-uri = postgresql://u:p@h/db?x=1") ==
+             {:ok, %{"db-uri" => "postgresql://u:p@h/db?x=1"}}
+  end
+
+  test "a line with no '=' is a malformed-line error" do
+    assert {:error, message} = ConfigFile.parse("not-a-valid-line")
+    assert message =~ "malformed config line"
+  end
 end

--- a/test/bier/cli/config_test.exs
+++ b/test/bier/cli/config_test.exs
@@ -1,0 +1,58 @@
+defmodule Bier.CLI.ConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Bier.CLI.Config
+
+  describe "coerce/2" do
+    test ":csv splits on commas" do
+      assert Config.coerce(:csv, "multi,tenant,setup") == {:ok, ["multi", "tenant", "setup"]}
+    end
+
+    test ":csv_emptyable yields [] for empty string" do
+      assert Config.coerce(:csv_emptyable, "") == {:ok, []}
+    end
+
+    test ":opt_int parses ints, treats wrong type as absent" do
+      assert Config.coerce(:opt_int, "1000") == {:ok, 1000}
+      assert Config.coerce(:opt_int, true) == {:ok, :unset}
+      assert Config.coerce(:opt_int, "") == {:ok, :unset}
+    end
+
+    test ":opt_string treats empty string as absent" do
+      assert Config.coerce(:opt_string, "") == {:ok, :unset}
+      assert Config.coerce(:opt_string, "x") == {:ok, "x"}
+    end
+
+    test "log-level enum maps known values, rejects unknown with PostgREST message" do
+      assert Config.coerce({:enum_atom, :log_level}, "info") == {:ok, :info}
+
+      assert Config.coerce({:enum_atom, :log_level}, "never") ==
+               {:error, "Invalid logging level. Check your configuration."}
+    end
+
+    test "db-tx-end enum rejects unknown with PostgREST message" do
+      assert Config.coerce({:enum_atom, :db_tx_end}, "commit-allow-override") ==
+               {:ok, :"commit-allow-override"}
+
+      assert Config.coerce({:enum_atom, :db_tx_end}, "random") ==
+               {:error, "Invalid transaction termination. Check your configuration."}
+    end
+
+    test "openapi-mode enum stays a string, rejects unknown with PostgREST message" do
+      assert Config.coerce({:enum_str, :openapi_mode}, "ignore-privileges") ==
+               {:ok, "ignore-privileges"}
+
+      assert Config.coerce({:enum_str, :openapi_mode}, "follow-") ==
+               {:error, "Invalid openapi-mode. Check your configuration."}
+    end
+  end
+
+  describe "spec/0" do
+    test "exposes db-schemas with its alias and env var" do
+      entry = Enum.find(Config.spec(), &(&1.key == "db-schemas"))
+      assert entry.env == "PGRST_DB_SCHEMAS"
+      assert "db-schema" in entry.aliases
+      assert entry.kind == :csv
+    end
+  end
+end

--- a/test/bier/cli/config_test.exs
+++ b/test/bier/cli/config_test.exs
@@ -176,6 +176,17 @@ defmodule Bier.CLI.ConfigTest do
       assert get_in(opts, [:router, :port]) == 4000
     end
 
+    test "percent-decodes db-uri credentials and database" do
+      {:ok, resolved} =
+        Config.load(%{"PGRST_DB_URI" => "postgresql://al%20ice:p%40ss@host/my%20db"}, nil, %{})
+
+      opts = Config.to_start_opts(resolved)
+
+      assert opts[:username] == "al ice"
+      assert opts[:password] == "p@ss"
+      assert opts[:database] == "my db"
+    end
+
     test "omits unset optional keys so Bier defaults apply" do
       {:ok, resolved} = Config.load(%{}, nil, %{})
       opts = Config.to_start_opts(resolved)

--- a/test/bier/cli/config_test.exs
+++ b/test/bier/cli/config_test.exs
@@ -149,4 +149,65 @@ defmodule Bier.CLI.ConfigTest do
       assert resolved["log-level"] == :debug
     end
   end
+
+  describe "dump/1" do
+    test "renders strings, ints, lists and unset values PostgREST-style" do
+      {:ok, resolved} =
+        Config.load(
+          %{
+            "PGRST_DB_SCHEMAS" => "multi,tenant,setup",
+            "PGRST_DB_MAX_ROWS" => "1000",
+            "PGRST_LOG_LEVEL" => "info"
+          },
+          nil,
+          %{}
+        )
+
+      dump = Config.dump(resolved) |> IO.iodata_to_binary()
+
+      assert dump =~ ~s(db-schemas = "multi,tenant,setup")
+      assert dump =~ ~s(db-max-rows = 1000)
+      assert dump =~ ~s(log-level = "info")
+      assert dump =~ ~s(db-anon-role = "")
+    end
+
+    test "an unset db-max-rows renders as empty string (case 1721)" do
+      {:ok, resolved} = Config.load(%{}, %{"db-max-rows" => true}, %{})
+      dump = Config.dump(resolved) |> IO.iodata_to_binary()
+      assert dump =~ ~s(db-max-rows = "")
+    end
+
+    test "db-tx-end round-trips its value (case 1722)" do
+      {:ok, resolved} = Config.load(%{"PGRST_DB_TX_END" => "commit-allow-override"}, nil, %{})
+      dump = Config.dump(resolved) |> IO.iodata_to_binary()
+      assert dump =~ ~s(db-tx-end = "commit-allow-override")
+    end
+
+    test "db-extra-search-path renders empty list as empty string (case 1728)" do
+      {:ok, resolved} = Config.load(%{"PGRST_DB_EXTRA_SEARCH_PATH" => ""}, nil, %{})
+      dump = Config.dump(resolved) |> IO.iodata_to_binary()
+      assert dump =~ ~s(db-extra-search-path = "")
+    end
+
+    test "dump output is reparse-stable (case 1726)" do
+      {:ok, resolved} =
+        Config.load(
+          %{
+            "PGRST_DB_MAX_ROWS" => "1000",
+            "PGRST_SERVER_PORT" => "80",
+            "PGRST_LOG_LEVEL" => "info"
+          },
+          nil,
+          %{}
+        )
+
+      dump1 = Config.dump(resolved) |> IO.iodata_to_binary()
+
+      {:ok, file} = Bier.CLI.ConfigFile.parse(dump1)
+      {:ok, resolved2} = Config.load(%{}, file, %{})
+      dump2 = Config.dump(resolved2) |> IO.iodata_to_binary()
+
+      assert dump1 == dump2
+    end
+  end
 end

--- a/test/bier/cli/config_test.exs
+++ b/test/bier/cli/config_test.exs
@@ -74,4 +74,71 @@ defmodule Bier.CLI.ConfigTest do
       assert entry.kind == :csv
     end
   end
+
+  describe "load/3" do
+    test "reads from environment only" do
+      env = %{
+        "PGRST_DB_SCHEMAS" => "multi,tenant,setup",
+        "PGRST_DB_MAX_ROWS" => "1000",
+        "PGRST_LOG_LEVEL" => "info"
+      }
+
+      assert {:ok, resolved} = Config.load(env, nil, %{})
+      assert resolved["db-schemas"] == ["multi", "tenant", "setup"]
+      assert resolved["db-max-rows"] == 1000
+      assert resolved["log-level"] == :info
+    end
+
+    test "env overrides file (case 1720)" do
+      file = %{"db-max-rows" => 100, "log-level" => "warn"}
+      env = %{"PGRST_DB_MAX_ROWS" => "999", "PGRST_LOG_LEVEL" => "debug"}
+      assert {:ok, resolved} = Config.load(env, file, %{})
+      assert resolved["db-max-rows"] == 999
+      assert resolved["log-level"] == :debug
+    end
+
+    test "resolves the db-schema alias (case 1730)" do
+      assert {:ok, resolved} = Config.load(%{}, %{"db-schema" => "aliased_schema"}, %{})
+      assert resolved["db-schemas"] == ["aliased_schema"]
+    end
+
+    test "wrong type for an optional int falls back to its default :unset (case 1721)" do
+      assert {:ok, resolved} = Config.load(%{}, %{"db-max-rows" => true}, %{})
+      assert resolved["db-max-rows"] == :unset
+    end
+
+    test "wrong type for a required int falls back to its numeric default (server-port)" do
+      assert {:ok, resolved} = Config.load(%{"PGRST_SERVER_PORT" => "garbage"}, nil, %{})
+      assert resolved["server-port"] == 3000
+    end
+
+    test "empty log-level falls back to default error, not an enum error (case 1723)" do
+      assert {:ok, resolved} = Config.load(%{"PGRST_LOG_LEVEL" => ""}, nil, %{})
+      assert resolved["log-level"] == :error
+    end
+
+    test "empty db-extra-search-path is the empty list, not the default (case 1728)" do
+      assert {:ok, resolved} = Config.load(%{"PGRST_DB_EXTRA_SEARCH_PATH" => ""}, nil, %{})
+      assert resolved["db-extra-search-path"] == []
+    end
+
+    test "a too-short jwt-secret is fatal (case 1708)" do
+      assert Config.load(%{"PGRST_JWT_SECRET" => "short_secret"}, nil, %{}) ==
+               {:error, "The JWT secret must be at least 32 characters long."}
+    end
+
+    test "an unknown log-level is fatal (case 1712)" do
+      assert Config.load(%{"PGRST_LOG_LEVEL" => "never"}, nil, %{}) ==
+               {:error, "Invalid logging level. Check your configuration."}
+    end
+
+    test "admin-server-port equal to server-port is fatal (case 1717)" do
+      assert Config.load(
+               %{"PGRST_SERVER_PORT" => "3000", "PGRST_ADMIN_SERVER_PORT" => "3000"},
+               nil,
+               %{}
+             ) ==
+               {:error, "admin-server-port cannot be the same as server-port"}
+    end
+  end
 end

--- a/test/bier/cli/config_test.exs
+++ b/test/bier/cli/config_test.exs
@@ -207,6 +207,48 @@ defmodule Bier.CLI.ConfigTest do
       opts = Config.to_start_opts(resolved)
       assert %Bier.Config{} = Bier.Config.new!(opts, Bier.schema())
     end
+
+    test "maps the bool observability keys and trace header" do
+      {:ok, resolved} =
+        Config.load(
+          %{"PGRST_DB_PLAN_ENABLED" => "true", "PGRST_SERVER_TRACE_HEADER" => "X-Request-Id"},
+          nil,
+          %{}
+        )
+
+      opts = Config.to_start_opts(resolved)
+
+      assert opts[:db_plan_enabled] == true
+      assert opts[:server_timing_enabled] == false
+      assert opts[:server_trace_header] == "X-Request-Id"
+    end
+
+    test "a fully-populated resolve produces options that all validate via Bier.Config.new!/2" do
+      env = %{
+        "PGRST_DB_URI" => "postgresql://u:p@h:5432/db",
+        "PGRST_DB_SCHEMAS" => "api,public",
+        "PGRST_DB_ANON_ROLE" => "anon",
+        "PGRST_DB_EXTRA_SEARCH_PATH" => "public,extra",
+        "PGRST_DB_MAX_ROWS" => "100",
+        "PGRST_DB_TX_END" => "rollback",
+        "PGRST_DB_PRE_REQUEST" => "auth.hook",
+        "PGRST_DB_ROOT_SPEC" => "root_fn",
+        "PGRST_SERVER_PORT" => "4000",
+        "PGRST_ADMIN_SERVER_PORT" => "4001",
+        "PGRST_JWT_SECRET" => "reallyreallyreallyreallyverysafe",
+        "PGRST_JWT_AUD" => "https://example.com",
+        "PGRST_OPENAPI_MODE" => "ignore-privileges",
+        "PGRST_LOG_LEVEL" => "info",
+        "PGRST_SERVER_CORS_ALLOWED_ORIGINS" => "http://example.com",
+        "PGRST_DB_PLAN_ENABLED" => "true",
+        "PGRST_SERVER_TRACE_HEADER" => "X-Request-Id",
+        "PGRST_SERVER_TIMING_ENABLED" => "true"
+      }
+
+      {:ok, resolved} = Config.load(env, nil, %{})
+      opts = Config.to_start_opts(resolved)
+      assert %Bier.Config{} = Bier.Config.new!(opts, Bier.schema())
+    end
   end
 
   describe "dump/1" do
@@ -246,6 +288,13 @@ defmodule Bier.CLI.ConfigTest do
       {:ok, resolved} = Config.load(%{"PGRST_DB_EXTRA_SEARCH_PATH" => ""}, nil, %{})
       dump = Config.dump(resolved) |> IO.iodata_to_binary()
       assert dump =~ ~s(db-extra-search-path = "")
+    end
+
+    test "bool keys render bare; default db-plan-enabled is false" do
+      {:ok, resolved} = Config.load(%{"PGRST_SERVER_TIMING_ENABLED" => "true"}, nil, %{})
+      dump = Config.dump(resolved) |> IO.iodata_to_binary()
+      assert dump =~ "server-timing-enabled = true"
+      assert dump =~ "db-plan-enabled = false"
     end
 
     test "dump output is reparse-stable (case 1726)" do

--- a/test/bier/cli/config_test.exs
+++ b/test/bier/cli/config_test.exs
@@ -150,6 +150,54 @@ defmodule Bier.CLI.ConfigTest do
     end
   end
 
+  describe "to_start_opts/1" do
+    test "maps resolved keys to Bier.start_link/1 options" do
+      {:ok, resolved} =
+        Config.load(
+          %{
+            "PGRST_DB_URI" => "postgresql://alice:secret@db.example.com:5433/shop",
+            "PGRST_DB_SCHEMAS" => "api,public",
+            "PGRST_SERVER_PORT" => "4000",
+            "PGRST_LOG_LEVEL" => "info"
+          },
+          nil,
+          %{}
+        )
+
+      opts = Config.to_start_opts(resolved)
+
+      assert opts[:hostname] == "db.example.com"
+      assert opts[:port] == 5433
+      assert opts[:database] == "shop"
+      assert opts[:username] == "alice"
+      assert opts[:password] == "secret"
+      assert opts[:db_schemas] == ["api", "public"]
+      assert opts[:log_level] == :info
+      assert get_in(opts, [:router, :port]) == 4000
+    end
+
+    test "omits unset optional keys so Bier defaults apply" do
+      {:ok, resolved} = Config.load(%{}, nil, %{})
+      opts = Config.to_start_opts(resolved)
+      refute Keyword.has_key?(opts, :db_max_rows)
+      refute Keyword.has_key?(opts, :jwt_secret)
+    end
+
+    test "collapses db-tx-end allow-override variants to Bier's base mode" do
+      {:ok, resolved} = Config.load(%{"PGRST_DB_TX_END" => "commit-allow-override"}, nil, %{})
+      opts = Config.to_start_opts(resolved)
+      assert opts[:db_tx_end] == :commit
+    end
+
+    test "produced options validate via Bier.Config.new!/2" do
+      {:ok, resolved} =
+        Config.load(%{"PGRST_DB_SCHEMAS" => "api", "PGRST_SERVER_PORT" => "4000"}, nil, %{})
+
+      opts = Config.to_start_opts(resolved)
+      assert %Bier.Config{} = Bier.Config.new!(opts, Bier.schema())
+    end
+  end
+
   describe "dump/1" do
     test "renders strings, ints, lists and unset values PostgREST-style" do
       {:ok, resolved} =

--- a/test/bier/cli/config_test.exs
+++ b/test/bier/cli/config_test.exs
@@ -140,5 +140,13 @@ defmodule Bier.CLI.ConfigTest do
              ) ==
                {:error, "admin-server-port cannot be the same as server-port"}
     end
+
+    test "flags override both env and file for the same key" do
+      flags = %{"log-level" => "debug"}
+      env = %{"PGRST_LOG_LEVEL" => "info"}
+      file = %{"log-level" => "warn"}
+      assert {:ok, resolved} = Config.load(env, file, flags)
+      assert resolved["log-level"] == :debug
+    end
   end
 end

--- a/test/bier/cli/config_test.exs
+++ b/test/bier/cli/config_test.exs
@@ -4,6 +4,25 @@ defmodule Bier.CLI.ConfigTest do
   alias Bier.CLI.Config
 
   describe "coerce/2" do
+    test ":string coerces any value to a string" do
+      assert Config.coerce(:string, "postgresql://") == {:ok, "postgresql://"}
+      assert Config.coerce(:string, 3000) == {:ok, "3000"}
+    end
+
+    test ":csv trims whitespace around items and drops empties" do
+      assert Config.coerce(:csv, " a , b ,") == {:ok, ["a", "b"]}
+    end
+
+    test ":bool is case-insensitive and accepts positive integers (PostgREST coerceBool)" do
+      assert Config.coerce(:bool, "TRUE") == {:ok, true}
+      assert Config.coerce(:bool, "true") == {:ok, true}
+      assert Config.coerce(:bool, "2") == {:ok, true}
+      assert Config.coerce(:bool, true) == {:ok, true}
+      assert Config.coerce(:bool, "0") == {:ok, false}
+      assert Config.coerce(:bool, "no") == {:ok, false}
+      assert Config.coerce(:bool, false) == {:ok, false}
+    end
+
     test ":csv splits on commas" do
       assert Config.coerce(:csv, "multi,tenant,setup") == {:ok, ["multi", "tenant", "setup"]}
     end

--- a/test/bier/cli_test.exs
+++ b/test/bier/cli_test.exs
@@ -1,0 +1,45 @@
+defmodule Bier.CLITest do
+  use ExUnit.Case, async: true
+
+  alias Bier.CLI
+
+  test "--dump-config prints config and exits 0" do
+    result = CLI.run(["--dump-config"], env: %{"PGRST_LOG_LEVEL" => "info"})
+    assert result.exit == 0
+    assert IO.iodata_to_binary(result.stdout) =~ ~s(log-level = "info")
+    assert IO.iodata_to_binary(result.stderr) == ""
+  end
+
+  test "--dump-config with an invalid value prints the message to stderr, nonzero exit" do
+    result = CLI.run(["--dump-config"], env: %{"PGRST_JWT_SECRET" => "short_secret"})
+    assert result.exit != 0
+
+    assert IO.iodata_to_binary(result.stderr) =~
+             "The JWT secret must be at least 32 characters long."
+
+    assert IO.iodata_to_binary(result.stdout) == ""
+  end
+
+  test "a missing config file is fatal" do
+    result = CLI.run(["does_not_exist.conf", "--dump-config"], env: %{})
+    assert result.exit != 0
+    assert IO.iodata_to_binary(result.stderr) =~ "does_not_exist.conf"
+  end
+
+  test "--version prints the version and exits 0" do
+    result = CLI.run(["--version"], env: %{})
+    assert result.exit == 0
+    assert IO.iodata_to_binary(result.stdout) =~ "bier"
+  end
+
+  test "--help prints usage and exits 0" do
+    result = CLI.run(["--help"], env: %{})
+    assert result.exit == 0
+    assert IO.iodata_to_binary(result.stdout) =~ "Usage"
+  end
+
+  test "no flag returns a boot directive" do
+    assert {:boot, resolved} = CLI.run([], env: %{"PGRST_LOG_LEVEL" => "info"})
+    assert resolved["log-level"] == :info
+  end
+end

--- a/test/bier/cli_test.exs
+++ b/test/bier/cli_test.exs
@@ -29,7 +29,7 @@ defmodule Bier.CLITest do
   test "--version prints the version and exits 0" do
     result = CLI.run(["--version"], env: %{})
     assert result.exit == 0
-    assert IO.iodata_to_binary(result.stdout) =~ "bier"
+    assert IO.iodata_to_binary(result.stdout) =~ ~r/bier \S/
   end
 
   test "--help prints usage and exits 0" do

--- a/test/bier/config_test.exs
+++ b/test/bier/config_test.exs
@@ -1,0 +1,37 @@
+defmodule Bier.ConfigTest do
+  use ExUnit.Case, async: true
+
+  describe "validate_jwt_secret/1" do
+    test "nil and >= 32 chars are ok" do
+      assert Bier.Config.validate_jwt_secret(nil) == :ok
+      assert Bier.Config.validate_jwt_secret(String.duplicate("a", 32)) == :ok
+    end
+
+    test "shorter than 32 chars is rejected with PostgREST's message" do
+      assert Bier.Config.validate_jwt_secret("short_secret") ==
+               {:error, "The JWT secret must be at least 32 characters long."}
+    end
+  end
+
+  describe "validate_jwt_aud/1" do
+    test "nil and a plain string are ok" do
+      assert Bier.Config.validate_jwt_aud(nil) == :ok
+      assert Bier.Config.validate_jwt_aud("my-audience") == :ok
+    end
+
+    test "a value containing ':' must be a valid URI" do
+      assert Bier.Config.validate_jwt_aud("https://example.com/aud") == :ok
+
+      assert Bier.Config.validate_jwt_aud("foo://%%$$^^.com") ==
+               {:error, "jwt-aud should be a string or a valid URI"}
+    end
+  end
+
+  describe "new!/2 enforces the validators" do
+    test "a too-short jwt_secret raises" do
+      assert_raise ArgumentError, ~r/JWT secret must be at least 32/, fn ->
+        Bier.Config.new!([jwt_secret: "short_secret"], Bier.schema())
+      end
+    end
+  end
+end

--- a/test/bier/config_test.exs
+++ b/test/bier/config_test.exs
@@ -21,6 +21,7 @@ defmodule Bier.ConfigTest do
 
     test "a value containing ':' must be a valid URI" do
       assert Bier.Config.validate_jwt_aud("https://example.com/aud") == :ok
+      assert Bier.Config.validate_jwt_aud("urn:example:audience") == :ok
 
       assert Bier.Config.validate_jwt_aud("foo://%%$$^^.com") ==
                {:error, "jwt-aud should be a string or a valid URI"}
@@ -31,6 +32,12 @@ defmodule Bier.ConfigTest do
     test "a too-short jwt_secret raises" do
       assert_raise ArgumentError, ~r/JWT secret must be at least 32/, fn ->
         Bier.Config.new!([jwt_secret: "short_secret"], Bier.schema())
+      end
+    end
+
+    test "an invalid jwt_aud raises" do
+      assert_raise ArgumentError, ~r/jwt-aud should be a string or a valid URI/, fn ->
+        Bier.Config.new!([jwt_aud: "foo://%%$$^^.com"], Bier.schema())
       end
     end
   end

--- a/test/conformance/conformance_test.exs
+++ b/test/conformance/conformance_test.exs
@@ -70,10 +70,13 @@ defmodule Bier.ConformanceTest do
         case_data = unquote(Macro.escape(c))
 
         resp =
-          case case_data.kind do
-            :cli -> Bier.CliCase.perform(case_data)
-            :http -> perform(case_data)
-          end
+          unquote(
+            if c.kind == :cli do
+              quote(do: Bier.CliCase.perform(var!(case_data)))
+            else
+              quote(do: perform(var!(case_data)))
+            end
+          )
 
         assert_expect(resp, case_data.expect)
       end

--- a/test/conformance/conformance_test.exs
+++ b/test/conformance/conformance_test.exs
@@ -3,21 +3,40 @@ defmodule Bier.ConformanceTest do
   One ExUnit test per spec conformance case. Fully-evaluable HTTP cases run
   against the shared Bier instance and currently FAIL (lib/ returns canned
   responses). Cases the current harness cannot evaluate are tagged :pending and
-  excluded (see pending_reason): :cli (no CLI), :jwt (needs JWT signing),
-  :openapi_doc (openapi body_jsonpath cases need the generated OpenAPI
-  document, #39), :status_text (req does not expose the HTTP reason phrase).
-  These are tracked for a follow-up, like the schema_cache deferral in
-  spec/COVERAGE.md.
+  excluded (see pending_reason): :jwt (needs JWT signing), :openapi_doc
+  (openapi body_jsonpath cases need the generated OpenAPI document, #39),
+  :status_text (req does not expose the HTTP reason phrase). CLI cases now run
+  directly via `Bier.CliCase` except those deferred as :cli_parity (full-table
+  dump / --example flag, cases 1705 and 1727), :unmodeled_key (config keys
+  Bier does not yet implement), or :db_config (DB role-settings source). These
+  are tracked for a follow-up, like the schema_cache deferral in spec/COVERAGE.md.
   """
   use Bier.HttpCase, async: true
 
   @moduletag :conformance
 
+  # CLI cases that map onto config Bier does not (yet) implement keep an honest
+  # pending reason instead of a façade. See
+  # docs/superpowers/specs/2026-06-07-cli-implementation-design.md.
+  @cli_deferred %{
+    1705 => :cli_parity,
+    1727 => :cli_parity,
+    1707 => :unmodeled_key,
+    1711 => :unmodeled_key,
+    1714 => :unmodeled_key,
+    1715 => :unmodeled_key,
+    1716 => :unmodeled_key,
+    1718 => :unmodeled_key,
+    1729 => :unmodeled_key,
+    1724 => :db_config,
+    1725 => :db_config
+  }
+
   for c <- Bier.ConformanceCase.load_all() do
     pending_reason =
       cond do
         c.kind == :cli ->
-          :cli
+          Map.get(@cli_deferred, c.id)
 
         Map.has_key?(c.request, "jwt") ->
           :jwt
@@ -49,7 +68,13 @@ defmodule Bier.ConformanceTest do
     else
       test "#{c.id} #{c.feature}" do
         case_data = unquote(Macro.escape(c))
-        resp = perform(case_data)
+
+        resp =
+          case case_data.kind do
+            :cli -> Bier.CliCase.perform(case_data)
+            :http -> perform(case_data)
+          end
+
         assert_expect(resp, case_data.expect)
       end
     end

--- a/test/support/cli_case.ex
+++ b/test/support/cli_case.ex
@@ -43,7 +43,7 @@ defmodule Bier.CliCase do
     Enum.map_join(file_map, "\n", fn {k, v} -> "#{k} = #{render_value(v)}" end) <> "\n"
   end
 
-  defp render_value(v) when is_binary(v), do: ~s("#{v}")
+  defp render_value(v) when is_binary(v), do: ~s("#{String.replace(v, ~S("), ~S(\"))}")
   defp render_value(v) when is_boolean(v), do: to_string(v)
   defp render_value(v) when is_integer(v), do: Integer.to_string(v)
 end

--- a/test/support/cli_case.ex
+++ b/test/support/cli_case.ex
@@ -1,0 +1,49 @@
+defmodule Bier.CliCase do
+  @moduledoc """
+  Drives a `kind: cli` conformance case through `Bier.CLI.run/2` in-process and
+  returns a normalized `%{stdout, stderr, exit}` map (iodata flattened to
+  strings). Any `config.file` map is written to a temp file; `config.env`
+  becomes the env map passed to the core.
+  """
+
+  @doc "Run a CLI conformance case and return its normalized result."
+  def perform(%Bier.ConformanceCase{request: req, config: config}) do
+    env = Map.get(config, "env", %{})
+    file_path = write_config_file(Map.get(config, "file"))
+    argv = build_argv(Map.get(req, "flag"), file_path)
+
+    try do
+      result = Bier.CLI.run(argv, env: env)
+
+      %{
+        stdout: IO.iodata_to_binary(result.stdout),
+        stderr: IO.iodata_to_binary(result.stderr),
+        exit: result.exit
+      }
+    after
+      if file_path, do: File.rm(file_path)
+    end
+  end
+
+  # The case `flag` is either a CLI flag ("--dump-config") or a config-file path
+  # that does not exist ("does_not_exist.conf", case 1719).
+  defp build_argv(nil, file_path), do: List.wrap(file_path)
+  defp build_argv("--" <> _ = flag, file_path), do: List.wrap(file_path) ++ [flag]
+  defp build_argv(path, _file_path), do: [path]
+
+  defp write_config_file(nil), do: nil
+
+  defp write_config_file(file_map) do
+    path = Path.join(System.tmp_dir!(), "bier_conf_#{System.unique_integer([:positive])}.conf")
+    File.write!(path, render_file(file_map))
+    path
+  end
+
+  defp render_file(file_map) do
+    Enum.map_join(file_map, "\n", fn {k, v} -> "#{k} = #{render_value(v)}" end) <> "\n"
+  end
+
+  defp render_value(v) when is_binary(v), do: ~s("#{v}")
+  defp render_value(v) when is_boolean(v), do: to_string(v)
+  defp render_value(v) when is_integer(v), do: Integer.to_string(v)
+end

--- a/test/support/conformance_assertions.ex
+++ b/test/support/conformance_assertions.ex
@@ -105,6 +105,41 @@ defmodule Bier.ConformanceAssertions do
     Enum.each(entries, &check_jsonpath_entry(&1, decoded))
   end
 
+  defp check("exit_code", "nonzero", resp) do
+    assert resp.exit != 0, "expected nonzero exit, got #{resp.exit}\nstderr: #{resp.stderr}"
+  end
+
+  defp check("exit_code", expected, resp) do
+    assert resp.exit == expected,
+           "expected exit #{expected}, got #{resp.exit}\nstderr: #{resp.stderr}"
+  end
+
+  defp check("dump_contains", needles, resp) when is_list(needles) do
+    Enum.each(needles, fn needle ->
+      assert String.contains?(resp.stdout, needle),
+             "dump did not contain #{inspect(needle)}\nfull dump:\n#{resp.stdout}"
+    end)
+  end
+
+  defp check("stderr_contains", needle, resp) when is_binary(needle) do
+    assert String.contains?(resp.stderr, needle),
+           "stderr did not contain #{inspect(needle)}\nfull stderr:\n#{resp.stderr}"
+  end
+
+  defp check("dump_reparse_stable", true, resp) do
+    path = Path.join(System.tmp_dir!(), "bier_reparse_#{System.unique_integer([:positive])}.conf")
+    File.write!(path, resp.stdout)
+
+    try do
+      second = Bier.CLI.run(["--dump-config", path], env: %{})
+
+      assert IO.iodata_to_binary(second.stdout) == resp.stdout,
+             "re-dumping the dumped config was not byte-identical"
+    after
+      File.rm(path)
+    end
+  end
+
   defp check(key, _val, _resp) do
     raise "unsupported assertion key: #{inspect(key)}"
   end

--- a/test/support/conformance_assertions.ex
+++ b/test/support/conformance_assertions.ex
@@ -114,6 +114,10 @@ defmodule Bier.ConformanceAssertions do
            "expected exit #{expected}, got #{resp.exit}\nstderr: #{resp.stderr}"
   end
 
+  defp check("dump_contains", [], _resp) do
+    raise "dump_contains must list at least one substring"
+  end
+
   defp check("dump_contains", needles, resp) when is_list(needles) do
     Enum.each(needles, fn needle ->
       assert String.contains?(resp.stdout, needle),


### PR DESCRIPTION
## Summary

Adds a standalone, drop-in **PostgREST-compatible CLI** for Bier (closes #40), re-scoped from "turn all 26 config CLI cases green" to **standalone-runnable Bier + drop-in config compat for the keys Bier actually implements**, with an honest conformance disposition for the rest. Design: `docs/superpowers/specs/2026-06-07-cli-implementation-design.md`; plan: `docs/superpowers/plans/2026-06-07-cli-implementation.md`.

- **`Bier.CLI`** — a pure, testable `run/2` core (`%{stdout, stderr, exit}` or `{:boot, resolved}`, no IO/halt) plus a thin escript `main/1` + single-instance boot path.
- **`Bier.CLI.Config`** — the PostgREST-dialect ↔ Bier boundary: a single-source-of-truth mapping table (`PGRST_*` env, kebab keys, aliases, defaults), `coerce/2`, `load/3` (precedence `flags > env > file > default`, alias resolution, wrong-type→default, shared validation), `dump/1` (PostgREST-format, reparse-stable), and `to_start_opts/1` (incl. `db-uri` parsing → discrete connection fields).
- **`Bier.CLI.ConfigFile`** — `key = value` config-file parser.
- **Shared validators** in `Bier.Config` (jwt-secret length, jwt-aud URI) so `Bier.start_link/1` and the CLI reject identically; exact PostgREST messages.
- **Conformance harness** — `Bier.CliCase` drives `kind: cli` cases through the core in-process; new `exit_code`/`dump_contains`/`stderr_contains`/`dump_reparse_stable` assertions.

## Conformance impact

15 of the 26 config CLI cases now pass (1706, 1708–1710, 1712, 1713, 1717, 1719–1723, 1726, 1728, 1730). The remaining 11 keep an explicit `pending_reason` instead of a parity façade: `:cli_parity` (full default-table dump 1705, `--example` 1727), `:unmodeled_key` (1707, 1711, 1714–1716, 1718, 1729 — keys Bier doesn't implement), `:db_config` (1724/1725 — DB role-settings source). Recorded in `spec/COVERAGE.md`.

Standalone packaging (`mix release` + Dockerfile) and `--ready` are deferred to #45.

## Test plan

- [x] `mix test` — 587 tests; the only 4 failures (GeoJSON 1616–1618, RS256 1467) are pre-existing on `main` (verified against the base commit), not regressions.
- [x] `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix docs --warnings-as-errors`, `mix hex.audit`, `mix deps.unlock --check-unused` — all clean.
- [x] escript smoke-tested: `mix escript.build && ./bier --dump-config | --version | --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)