### PR TITLE
feat(#45): standalone packaging — mix release + Dockerfile for `docker run bier`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Build artifacts and deps are rebuilt inside the image.
+/_build/
+/deps/
+/cover/
+/doc/
+/tmp/
+
+# Tests, fixtures, and docs are not needed for the prod release.
+/test/
+/spec/
+/docs/
+/bench/
+
+# Git, editor, and local tooling.
+/.git/
+/.github/
+/.elixir_ls/
+/.claude/
+erl_crash.dump
+
+# The escript binary and package tarballs.
+/bier
+bier-*.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build for the standalone Bier server.
+#   docker build -t bier .
+#   docker run --rm -e PGRST_DB_URI=postgresql://user:pass@host:5432/db \
+#                    -e PGRST_DB_SCHEMAS=api -e PGRST_DB_ANON_ROLE=web_anon \
+#                    -p 3000:3000 bier
+#
+# The image runs `bin/bier start`, which boots ONE Bier instance from PGRST_*
+# env vars (BIER_STANDALONE=1 is baked in). See README "Running standalone".
+
+ARG ELIXIR_IMAGE=hexpm/elixir:1.19.5-erlang-28.5.0.1-debian-bookworm-20260518-slim
+ARG RUNTIME_IMAGE=debian:bookworm-slim
+
+# ---- build stage ----
+FROM ${ELIXIR_IMAGE} AS build
+
+RUN apt-get update -y \
+    && apt-get install -y build-essential git \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+RUN mix local.hex --force && mix local.rebar --force
+
+ENV MIX_ENV=prod
+
+# Fetch & compile prod dependencies (cached unless mix.exs/mix.lock change).
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only prod
+RUN mix deps.compile
+
+# Compile-time config and source, then assemble the release.
+COPY config config
+COPY lib lib
+RUN mix compile
+RUN mix release
+
+# ---- runtime stage ----
+FROM ${RUNTIME_IMAGE} AS app
+
+# The release bundles ERTS, so only the C libraries it links against are needed.
+RUN apt-get update -y \
+    && apt-get install -y libstdc++6 openssl libncurses6 locales ca-certificates \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Elixir/Erlang need a UTF-8 locale.
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
+
+WORKDIR /app
+COPY --from=build --chown=nobody:root /app/_build/prod/rel/bier ./
+USER nobody
+
+# Run as a standalone server configured entirely via PGRST_* env vars.
+ENV BIER_STANDALONE=1
+ENV PGRST_SERVER_PORT=3000
+EXPOSE 3000
+
+ENTRYPOINT ["/app/bin/bier"]
+CMD ["start"]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,64 @@ default, which requires Elixir 1.18+). Override it with:
 config :bier, :json_library, Jason
 ```
 
+## Running standalone
+
+Bier is primarily a library you embed (see [Usage](#usage)), but it can also run
+as a **standalone server** — no host application required — configured entirely
+from PostgREST-compatible `PGRST_*` environment variables. This is a config-level
+drop-in for PostgREST for the settings Bier implements.
+
+### Docker
+
+```sh
+docker build -t bier .
+
+docker run --rm -p 3000:3000 \
+  -e PGRST_DB_URI="postgresql://authenticator:secret@db:5432/app" \
+  -e PGRST_DB_SCHEMAS="api" \
+  -e PGRST_DB_ANON_ROLE="web_anon" \
+  bier
+```
+
+The image runs `bin/bier start`, which boots one instance bound to
+`PGRST_SERVER_PORT` (default `3000`). A fatal config problem (e.g. a JWT secret
+shorter than 32 characters) is printed to stderr and aborts startup.
+
+### Release
+
+`MIX_ENV=prod mix release` builds a self-contained release under
+`_build/prod/rel/bier`:
+
+```sh
+MIX_ENV=prod mix release
+
+BIER_STANDALONE=1 \
+PGRST_DB_URI="postgresql://authenticator:secret@localhost:5432/app" \
+PGRST_DB_SCHEMAS="api" \
+PGRST_DB_ANON_ROLE="web_anon" \
+_build/prod/rel/bier/bin/bier start
+```
+
+`BIER_STANDALONE=1` is what tells `Bier.Application` to boot an instance from the
+environment; it is baked into the Docker image. Without it (the default), the
+application starts only its registry, so embedding Bier in a host app is
+unaffected.
+
+### Inspecting configuration
+
+The `bier` escript (`mix escript.build`) resolves and prints the effective
+config without starting a server — useful for debugging a deployment's env:
+
+```sh
+PGRST_DB_SCHEMAS=api ./bier --dump-config
+./bier --help
+```
+
+Supported `PGRST_*` keys mirror the [Configuration](#configuration) table
+(`PGRST_DB_URI`, `PGRST_DB_SCHEMAS`, `PGRST_SERVER_PORT`, `PGRST_JWT_SECRET`,
+`PGRST_LOG_LEVEL`, …) plus their deprecated PostgREST aliases. Keys Bier does not
+implement are intentionally not accepted rather than silently echoed.
+
 ## Architecture
 
 There are two supervisors with different jobs. `Bier.Application` (the OTP `mod:`)

--- a/lib/bier/application.ex
+++ b/lib/bier/application.ex
@@ -7,13 +7,46 @@ defmodule Bier.Application do
 
   @impl true
   def start(_type, _args) do
-    children = [
-      Bier.Registry
-    ]
+    children = [Bier.Registry | standalone_children(System.get_env())]
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Bier.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  # When `BIER_STANDALONE` is set, boot one Bier instance from `PGRST_*` env via
+  # the CLI config loader — this is how the release / Docker image runs Bier as a
+  # standalone service. Inert otherwise, so the test suite and host apps that
+  # embed Bier via `Bier.start_link/1` are unaffected. A fatal config problem
+  # aborts boot with the message on stderr (fail fast, like PostgREST).
+  @doc false
+  def standalone_children(env) do
+    case standalone_spec(env) do
+      :none ->
+        []
+
+      {:ok, child} ->
+        [child]
+
+      {:error, message} ->
+        IO.puts(:stderr, message)
+        System.halt(1)
+    end
+  end
+
+  # Pure decision split out from `standalone_children/1` so it is testable
+  # without halting the VM: returns `:none`, `{:ok, child_spec}`, or
+  # `{:error, message}`.
+  @doc false
+  def standalone_spec(env) do
+    if env["BIER_STANDALONE"] in ["1", "true"] do
+      case Bier.CLI.Config.load(env, nil, %{}) do
+        {:ok, resolved} -> {:ok, {Bier, Bier.CLI.Config.to_start_opts(resolved)}}
+        {:error, _message} = err -> err
+      end
+    else
+      :none
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,7 @@ defmodule Bier.MixProject do
       test_coverage: [tool: ExCoveralls],
       aliases: aliases(),
       escript: escript(),
+      releases: releases(),
       deps: deps()
     ]
   end
@@ -40,6 +41,18 @@ defmodule Bier.MixProject do
 
   defp escript do
     [main_module: Bier.CLI, app: nil]
+  end
+
+  # Standalone-server release: `MIX_ENV=prod mix release` builds a self-contained
+  # `bier` release whose `bin/bier start` boots one instance from `PGRST_*` env
+  # (see `Bier.Application` + `BIER_STANDALONE`). Used by the Dockerfile.
+  defp releases do
+    [
+      bier: [
+        include_executables_for: [:unix],
+        applications: [bier: :permanent]
+      ]
+    ]
   end
 
   defp aliases do

--- a/test/bier/application_test.exs
+++ b/test/bier/application_test.exs
@@ -1,0 +1,34 @@
+defmodule Bier.ApplicationTest do
+  use ExUnit.Case, async: true
+
+  describe "standalone_spec/1" do
+    test "without the BIER_STANDALONE flag it is inert (:none)" do
+      assert Bier.Application.standalone_spec(%{}) == :none
+      assert Bier.Application.standalone_spec(%{"BIER_STANDALONE" => "0"}) == :none
+    end
+
+    test "with BIER_STANDALONE set and valid config it returns a {Bier, opts} child" do
+      env = %{
+        "BIER_STANDALONE" => "1",
+        "PGRST_DB_SCHEMAS" => "api",
+        "PGRST_SERVER_PORT" => "4000"
+      }
+
+      assert {:ok, {Bier, opts}} = Bier.Application.standalone_spec(env)
+      assert opts[:db_schemas] == ["api"]
+      assert get_in(opts, [:router, :port]) == 4000
+    end
+
+    test "accepts \"true\" as well as \"1\" for the flag" do
+      assert {:ok, {Bier, _opts}} =
+               Bier.Application.standalone_spec(%{"BIER_STANDALONE" => "true"})
+    end
+
+    test "with BIER_STANDALONE set and invalid config it returns the fatal message" do
+      env = %{"BIER_STANDALONE" => "1", "PGRST_JWT_SECRET" => "short"}
+
+      assert Bier.Application.standalone_spec(env) ==
+               {:error, "The JWT secret must be at least 32 characters long."}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements #45 (standalone packaging), stacked on top of the #40 CLI branch
(`worktree-cli-implementation`) — **this PR targets that branch, not `main`.**
It makes Bier runnable as a standalone service with zero host application,
configured entirely from `PGRST_*` env vars.

- **`Bier.Application`** gains a `BIER_STANDALONE`-gated path: when the flag is
  set it loads `PGRST_*` env via `Bier.CLI.Config` and boots exactly one
  instance; a fatal config problem prints to stderr and aborts. Inert by default,
  so the test suite and host apps that embed Bier via `Bier.start_link/1` are
  unaffected. The decision is split into a pure, unit-tested `standalone_spec/1`.
- **`mix.exs`** — a `releases:` entry so `MIX_ENV=prod mix release` builds a
  self-contained `bier` release.
- **`Dockerfile`** (multi-stage, pinned Elixir 1.19.5 / OTP 28, debian-bookworm)
  + `.dockerignore`; the image sets `BIER_STANDALONE=1` and runs `bin/bier start`.
- **README** — a "Running standalone" section (Docker, release, `--dump-config`).

## Verification

- [x] `mix test` — 591 tests; the only 4 failures (GeoJSON 1616–1618, RS256 1467) are pre-existing on `main`, not regressions. `mix format --check-formatted` clean.
- [x] `MIX_ENV=prod mix release` builds; the release booted from `PGRST_*` env against a real Postgres and served `GET /items?limit=1` → `HTTP 200 [{"id":1}]`.
- [x] `docker build` succeeds (~147 MB image); `docker run … version` works in-container; and a full `docker run` configured only via `PGRST_*` env connected to the DB, bound `0.0.0.0:3000`, and served `GET /items?limit=1` → `HTTP 200 [{"id":1}]`.

## Notes / out of scope

- `--ready` and the `db-config` (DB role-settings) source remain tracked on #45.
- The `db-max-rows=0` / out-of-range-port boot-hardening (clean error vs raw crash) is noted on #45; not addressed here.
- Stacked PR: review/merge after #40 (PR #48). Once #48 merges to `main`, this PR's base can be retargeted to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)